### PR TITLE
Type annotation

### DIFF
--- a/extract_ciod_module_data.py
+++ b/extract_ciod_module_data.py
@@ -26,7 +26,7 @@ def is_valid_ciod_table(table_div):
 
 
 def tables_to_json(tables, tdivs):
-    expanded_tables = list(map(expand_spans, tables))
+    expanded_tables = map(expand_spans, tables)
     stringified_tables = map(stringify_table, expanded_tables)
     table_dicts = map(ciod_table_to_dict, stringified_tables)
     return list(map(get_table_with_metadata, zip(table_dicts, tdivs)))

--- a/extract_macros.py
+++ b/extract_macros.py
@@ -3,12 +3,15 @@ Load the macro tables specified throughout PS3.3 in the DICOM Standard.
 These tables are of the same form as the module-attribute tables and
 are used to expand macro references in Annex C.
 '''
+from typing import Tuple, List, Dict, Any, Iterator
 import sys
 import re
 
+from bs4 import BeautifulSoup, Tag
+
 import parse_lib as pl
 import parse_relations as pr
-from table_utils import expand_spans, table_to_dict, stringify_table, tdiv_to_table_list
+from table_utils import expand_spans, stringify_table, tdiv_to_table_list
 from macro_utils import get_id_from_link
 
 # Macros and modules require the same metadata and formatting,
@@ -17,19 +20,21 @@ from extract_modules_with_attributes import module_table_to_dict, get_table_with
 
 TABLE_SUFFIX_RE = re.compile("(.*Macro Attributes$)|(.*Macro Attributes Description$)")
 
+TableListType = List[List[Tag]]
+MetadataTableType = Dict[str, Any]
 
-def get_macro_tables(standard):
+def get_macro_tables(standard: BeautifulSoup) -> Tuple[List[TableListType], List[Tag]]:
     all_table_divs = standard.find_all('div', class_='table')
     macro_table_divs = list(filter(is_valid_macro_table, all_table_divs))
     macro_table_lists = list(map(tdiv_to_table_list, macro_table_divs))
     return (macro_table_lists, macro_table_divs)
 
 
-def is_valid_macro_table(table_div):
-    return TABLE_SUFFIX_RE.match(pr.table_name(table_div))
+def is_valid_macro_table(table_div: Tag) -> bool:
+    return bool(TABLE_SUFFIX_RE.match(pr.table_name(table_div)))
 
 
-def tables_to_json(tables, tdivs):
+def tables_to_json(tables: List[TableListType], tdivs: List[Tag]) -> Dict[str, MetadataTableType]:
     expanded_tables = map(expand_spans, tables)
     stringified_tables = map(stringify_table, expanded_tables)
     table_dicts = map(module_table_to_dict, stringified_tables)
@@ -37,7 +42,7 @@ def tables_to_json(tables, tdivs):
     return key_tables_by_id(list_of_tables)
 
 
-def key_tables_by_id(list_of_tables):
+def key_tables_by_id(list_of_tables: Iterator[MetadataTableType]) -> Dict[str, MetadataTableType]:
     dict_of_tables = {}
     for table in list_of_tables:
         dict_of_tables[get_id_from_link(table['linkToStandard'])] = table

--- a/extract_macros.py
+++ b/extract_macros.py
@@ -30,10 +30,10 @@ def is_valid_macro_table(table_div):
 
 
 def tables_to_json(tables, tdivs):
-    expanded_tables = list(map(expand_spans, tables))
+    expanded_tables = map(expand_spans, tables)
     stringified_tables = map(stringify_table, expanded_tables)
     table_dicts = map(module_table_to_dict, stringified_tables)
-    list_of_tables = list(map(get_table_with_metadata, zip(table_dicts, tdivs)))
+    list_of_tables = map(get_table_with_metadata, zip(table_dicts, tdivs))
     return key_tables_by_id(list_of_tables)
 
 

--- a/extract_modules_with_attributes.py
+++ b/extract_modules_with_attributes.py
@@ -27,7 +27,7 @@ def is_valid_module_table(table_div):
 
 
 def tables_to_json(tables, tdivs):
-    expanded_tables = list(map(expand_spans, tables))
+    expanded_tables = map(expand_spans, tables)
     stringified_tables = map(stringify_table, expanded_tables)
     table_dicts = map(module_table_to_dict, stringified_tables)
     return list(map(get_table_with_metadata, zip(table_dicts, tdivs)))

--- a/hierarchy_utils.py
+++ b/hierarchy_utils.py
@@ -2,25 +2,28 @@
 Utility functions for managing the hierarchy structure of
 attributes in the module-attribute relationship tables
 '''
+from typing import Dict, List, Tuple
 import re
+
+from bs4 import Tag
 
 import parse_lib as pl
 
-def get_hierarchy_markers(name):
+def get_hierarchy_markers(name: str) -> str:
     clean_name = name.strip().replace('\n', '')
     _, *split = re.split('^(>+)', clean_name)
     return '' if split == [] else split[0]
 
 
-def get_hierarchy_level(name):
+def get_hierarchy_level(name: str) -> int:
     return len(get_hierarchy_markers(name))
 
 
-def clean_field(name):
+def clean_field(name: str) -> str:
     return re.sub(r'[>]', '', name).strip()
 
 
-def record_hierarchy_for_module(table):
+def record_hierarchy_for_module(table: Tag) -> Tag:
     last_id = [table['id']]
     current_level = -1
     for attr in table['attributes']:
@@ -29,7 +32,7 @@ def record_hierarchy_for_module(table):
     return table
 
 
-def update_hierarchy_position(attr, last_id, current_level):
+def update_hierarchy_position(attr: Dict[str, str], last_id: List[str], current_level: int) -> Tuple[List[str], int]:
     attr_id = pl.create_slug(clean_field(attr['tag']))
     attribute_level = get_hierarchy_level(attr['name'])
     delta_l = attribute_level - current_level
@@ -55,7 +58,7 @@ def update_hierarchy_position(attr, last_id, current_level):
     return last_id, current_level
 
 
-def format_attribute_fields(attr, last_id):
+def format_attribute_fields(attr: Dict[str, str], last_id: List[str]) -> None:
     attr['name'] = clean_field(attr['name'])
     attr['tag'] = clean_field(attr['tag'])
     attr['type'] = clean_field(attr['type'])

--- a/parse_lib.py
+++ b/parse_lib.py
@@ -23,7 +23,7 @@ def parse_html_file(filepath: str) -> BeautifulSoup:
         return BeautifulSoup(html_file, 'html.parser')
 
 
-def write_pretty_json(data):
+def write_pretty_json(data: Any) -> None:
     json.dump(data, sys.stdout, sort_keys=False, indent=4, separators=(',', ':'))
 
 
@@ -129,14 +129,14 @@ def update_anchor_href(anchor: Tag) -> None:
         anchor['target'] = '_blank'
 
 
-def convert_svg_obj_to_img(html, equation):
+def convert_svg_obj_to_img(html: BeautifulSoup, svg: Tag):
     '''
     Since the DICOM standard represents SVG images as `object` tags,
     they can be converted to standard `img` tags by copying the object
     `data` field into `src`. This removes some complex SVG metadata HTML
     included by the standard.
     '''
-    img_tag = html.new_tag('img', src=equation['data'])
+    img_tag = html.new_tag('img', src=svg['data'])
     return img_tag
 
 
@@ -184,7 +184,7 @@ def get_long_html_location(reference_link: str) -> str:
     return chapter_with_extension + '#' + section_id
 
 
-def resolve_img_src(resource: Tag):
+def resolve_img_src(resource: Tag) -> None:
     if not has_protocol_prefix(resource, 'src'):
         resource['src'] = BASE_DICOM_URL + resource['src']
 

--- a/parse_relations.py
+++ b/parse_relations.py
@@ -3,18 +3,20 @@ Convenience functions for common relations in the DICOM HTML.
 Many of these relations are obscure-looking nested accesses,
 but they are consistent relations across the HTML source.
 '''
+from typing import List
+from bs4 import Tag
 
-def table_rows(table_div):
+def table_rows(table_div: Tag) -> List[Tag]:
     return table_div.find('tbody').find_all('tr')
 
 
-def table_name(table_div):
+def table_name(table_div: Tag) -> str:
     return table_div.p.strong.get_text()
 
 
-def table_id(table_div):
+def table_id(table_div: Tag) -> str:
     return table_div.a.get('id')
 
 
-def table_description(table_div):
+def table_description(table_div: Tag) -> Tag:
     return table_div.parent.find('p')

--- a/postprocess_mark_references.py
+++ b/postprocess_mark_references.py
@@ -26,7 +26,8 @@ def record_reference_in_pair(pair):
     parsed_description = BeautifulSoup(pair['description'], 'html.parser')
     references = get_valid_reference_anchors(parsed_description)
     external_references = list(map(reference_structure_from_anchor, references))
-    list(map(mark_as_recorded, references))
+    for ref in references:
+        mark_as_recorded(ref)
     pair['externalReferences'] = [] if len(external_references) < 1 else external_references
     pair['description'] = str(parsed_description)
     finalize_descriptions(pair)

--- a/process_ciod_module_relationship.py
+++ b/process_ciod_module_relationship.py
@@ -1,31 +1,29 @@
 '''
 Takes the extracted CIOD-Module table information to build a list of all
-CIOD-Module relationships enumerated in the DICOM Standard.
+CIOD-Module relationships defined in the DICOM Standard.
 '''
 import sys
-from bs4 import BeautifulSoup as bs
 
 import parse_lib as pl
 
-def enumerate_all_relationships(ciod_module_list):
+def define_all_relationships(ciod_module_list):
     all_relationships = []
     for table in ciod_module_list:
-        all_relationships.extend(list(map(describe_relationship_with(table['name']),
-                                          table['modules'])))
+        ciod = table['name']
+        modules = table['modules']
+        all_relationships.extend([define_ciod_module_relationship(ciod, module) for module in modules])
     return all_relationships
 
 
-def describe_relationship_with(ciod_name):
-    def enumerate_relationship(module):
-        usage, conditional_statement = expand_conditional_statement(module['usage'])
-        return {
-            "ciod": pl.create_slug(ciod_name),
-            "module": pl.create_slug(pl.text_from_html_string(module['module'])),
-            "usage": usage,
-            "conditionalStatement": conditional_statement,
-            "informationEntity": pl.text_from_html_string(module['informationEntity'])
-        }
-    return enumerate_relationship
+def define_ciod_module_relationship(ciod, module):
+    usage, conditional_statement = expand_conditional_statement(module['usage'])
+    return {
+        "ciod": pl.create_slug(ciod),
+        "module": pl.create_slug(pl.text_from_html_string(module['module'])),
+        "usage": usage,
+        "conditionalStatement": conditional_statement,
+        "informationEntity": pl.text_from_html_string(module['informationEntity'])
+    }
 
 
 def expand_conditional_statement(usage_field_html):
@@ -55,5 +53,5 @@ def extract_conditional_statement(usage_field):
 
 if __name__ == '__main__':
     ciod_module_list = pl.read_json_to_dict(sys.argv[1])
-    ciod_module_relationships = enumerate_all_relationships(ciod_module_list)
+    ciod_module_relationships = define_all_relationships(ciod_module_list)
     pl.write_pretty_json(ciod_module_relationships)

--- a/table_utils.py
+++ b/table_utils.py
@@ -2,32 +2,34 @@
 Functions for low-level manipulation of standard tables,
 represented by a list-of-lists.
 '''
+from typing import List, Tuple, Dict
 from copy import copy
-from bs4 import BeautifulSoup as bs
+from bs4 import Tag
 
 import parse_relations as pr
+from extract_macros import TableListType
 
-def table_to_dict(table, row_names):
+def table_to_dict(table: TableListType, row_names: List[str]) -> List[Dict[str, List[Tag]]]:
     return [dict(zip(row_names, row)) for row in table]
 
 
-def stringify_table(table):
+def stringify_table(table: TableListType) -> List[List[str]]:
     return [[str(cell) for cell in row] for row in table]
 
 
-def tdiv_to_table_list(table_div):
+def tdiv_to_table_list(table_div: Tag) -> List[List[Tag]]:
     rows = pr.table_rows(table_div)
     table = [row.find_all('td') for row in rows]
     return table
 
 
-def expand_spans(table):
+def expand_spans(table: TableListType) -> TableListType:
     rowwise_expanded_table = expand_rows(table)
     fully_expanded_table = list(map(expand_columns_in_row, rowwise_expanded_table))
     return fully_expanded_table
 
 
-def expand_rows(table):
+def expand_rows(table: TableListType) -> TableListType:
     '''
     We can't perform a more graceful iteration through the table
     (i.e. a map or comprehension) because information must be
@@ -41,13 +43,13 @@ def expand_rows(table):
     return extended_table
 
 
-def expand_rowspans(row, row_expansion):
+def expand_rowspans(row: List[Tag], row_expansion: List[Tuple[Tag, int]]) -> Tuple[List[Tag], List[Tuple[Tag, int]]]:
     updated_row = apply_rowspans_from_prev_row(row, row_expansion)
     row_expansion = update_row_expansion_counter(updated_row, row_expansion)
     return updated_row, row_expansion
 
 
-def apply_rowspans_from_prev_row(row, row_expansion):
+def apply_rowspans_from_prev_row(row: List[Tag], row_expansion: List[Tuple[Tag, int]]) -> List[Tag]:
     updated_row = row
     for cell, cell_idx in row_expansion:
         cell = decrement_rowspan_counter(cell)
@@ -55,13 +57,13 @@ def apply_rowspans_from_prev_row(row, row_expansion):
     return updated_row
 
 
-def add_row_cell(row, cell, cell_idx):
+def add_row_cell(row: List[Tag], cell: Tag, cell_idx: int) -> List[Tag]:
     updated_row = slide_down(cell_idx, row)
     updated_row[cell_idx] = cell
     return updated_row
 
 
-def slide_down(start_idx, row, num_slides=1):
+def slide_down(start_idx: int, row: List[Tag], num_slides: int = 1) -> List[Tag]:
     '''
     Move elements of array `row` down by `num_slides` number of spaces,
     starting at index `start_idx`. Fills the spaces with None.
@@ -77,17 +79,17 @@ def slide_down(start_idx, row, num_slides=1):
         raise ValueError('Cell spans beyond table!')
 
 
-def decrement_rowspan_counter(cell):
+def decrement_rowspan_counter(cell: Tag) -> Tag:
     if int(cell['rowspan']) >= 2:
         cell['rowspan'] = int(cell['rowspan']) - 1
     return cell
 
 
-def clear_rowspan_counter(cell):
+def clear_rowspan_counter(cell: Tag) -> None:
     cell['rowspan'] = 1
 
 
-def update_row_expansion_counter(row, row_expansion):
+def update_row_expansion_counter(row: List[Tag], row_expansion: List[Tuple[Tag, int]]) -> List[Tuple[Tag, int]]:
     row_expansion = remove_completed_rowspans(row_expansion)
     for idx, cell in enumerate(row):
         if is_new_rowspan_cell(cell, idx, row_expansion):
@@ -96,28 +98,28 @@ def update_row_expansion_counter(row, row_expansion):
     return row_expansion
 
 
-def is_new_rowspan_cell(cell, idx, row_expansion):
+def is_new_rowspan_cell(cell: Tag, idx: int, row_expansion: List[Tuple[Tag, int]]) -> bool:
     is_not_recorded = (cell, idx) not in row_expansion
     return has_rowspans_to_expand(cell) and is_not_recorded
 
 
-def remove_completed_rowspans(row_expansion):
+def remove_completed_rowspans(row_expansion: List[Tuple[Tag, int]]) -> List[Tuple[Tag, int]]:
     return [(cell,idx) for (cell, idx) in row_expansion
             if has_rowspans_to_expand(cell)]
 
 
-def has_rowspans_to_expand(cell):
+def has_rowspans_to_expand(cell: Tag) -> bool:
     rowspan_attr = cell.get('rowspan')
     return int(cell.get('rowspan')) > 1 if rowspan_attr is not None else None
 
 
-def expand_columns_in_row(row):
+def expand_columns_in_row(row: List[Tag]) -> List[Tag]:
     expanded_cells = map(expand_cell_colspan, row)
     return [cell for span_of_cells in expanded_cells
             for cell in span_of_cells]
 
 
-def expand_cell_colspan(cell):
+def expand_cell_colspan(cell: Tag) -> Tag:
     colspan_count = cell.get('colspan')
     expanded_cell = [cell]
     if colspan_count is not None:


### PR DESCRIPTION
This PR is based on the `fix-svg` branch.

Add provisional type annotations to library functions. The goal is to provide type context for complex portions of the parse logic, particularly low-level operations like table and row manipulations.