### PR TITLE
Process "Current Frame Functional Groups" macro attributes

### DIFF
--- a/dicom_standard/extract_ciod_func_group_macro_tables.py
+++ b/dicom_standard/extract_ciod_func_group_macro_tables.py
@@ -18,7 +18,6 @@ from dicom_standard.table_utils import (
     get_chapter_tables,
     tables_to_json,
     get_short_standard_link,
-    get_table_description,
     table_to_dict,
 )
 
@@ -49,13 +48,17 @@ def macro_table_to_dict(table: StringifiedTableListType) -> List[TableDictType]:
 def get_table_with_metadata(table_with_tdiv: Tuple[List[TableDictType], Tag]) -> MetadataTableType:
     table, tdiv = table_with_tdiv
     clean_name = clean_macro_table_name(pr.table_name(tdiv))
-    table_description = get_table_description(tdiv)
+    clean_description = pl.clean_html(str(tdiv.find_previous('p')))
+    module_type = 'Multi-frame' if 'Multi-frame' in clean_description \
+        else 'Current Frame' if 'Current Frame' in clean_description \
+        else None
     return {
         'name': clean_name,
         'macros': table,
         'id': pl.create_slug(clean_name),
-        'description': str(table_description),
-        'linkToStandard': get_short_standard_link(tdiv)
+        'description': clean_description,
+        'linkToStandard': get_short_standard_link(tdiv),
+        'moduleType': module_type,
     }
 
 

--- a/dicom_standard/postprocess_integrate_func_group_macros.py
+++ b/dicom_standard/postprocess_integrate_func_group_macros.py
@@ -6,10 +6,11 @@ from copy import deepcopy
 from operator import itemgetter
 
 import dicom_standard.parse_lib as pl
-from dicom_standard.process_modules import FUNC_GROUP_MODULE_ID
+from dicom_standard.process_modules import MF_FUNC_GROUP_MODULE_ID, CF_FUNC_GROUP_MODULE_ID
 
-SHARED_FUNC_GROUP_ID = 52009229
-PER_FRAME_FUNC_GROUP_ID = 52009230
+SHARED_FUNC_GROUP_ID = '52009229'
+PER_FRAME_FUNC_GROUP_ID = '52009230'
+CURRENT_FRAME_FUNC_GROUP_ID = '00060001'
 
 
 def update_description(attribute, macro):
@@ -25,14 +26,15 @@ def update_description(attribute, macro):
 def convert_macro_attr(macro_attr, macro, fg_attr_id):
     attr = deepcopy(macro_attr)
     macro_id = attr.pop('macroId')
-    attr['moduleId'] = f'{macro["ciodId"]}-{FUNC_GROUP_MODULE_ID}'
+    fg_module_id = CF_FUNC_GROUP_MODULE_ID if fg_attr_id == CURRENT_FRAME_FUNC_GROUP_ID else MF_FUNC_GROUP_MODULE_ID
+    attr['moduleId'] = f'{macro["ciodId"]}-{fg_module_id}'
     new_path_prefix = f'{attr["moduleId"]}:{fg_attr_id}'
     attr['path'] = attr['path'].replace(macro_id, new_path_prefix)
     update_description(attr, macro)
     return attr
 
 
-def process_macro_attributes(macro_attrs, macro):
+def process_mffg_macro_attributes(macro_attrs, macro):
     attr_list = []
     for macro_attr in macro_attrs:
         attr_list.append(convert_macro_attr(macro_attr, macro, SHARED_FUNC_GROUP_ID))
@@ -40,14 +42,19 @@ def process_macro_attributes(macro_attrs, macro):
     return attr_list
 
 
-def process_mffg_attributes(ciods, mffg_attrs):
+def process_cffg_macro_attributes(macro_attrs, macro):
+    return [convert_macro_attr(macro_attr, macro, CURRENT_FRAME_FUNC_GROUP_ID) for macro_attr in macro_attrs]
+
+
+def process_fg_attributes(module_to_attr, ciods, fg_module_id):
+    fg_attrs = list(filter(lambda r: r['moduleId'] == fg_module_id, module_to_attr))
     attr_list = []
     for ciod in ciods:
-        module_id = f'{ciod}-{FUNC_GROUP_MODULE_ID}'
-        for mffg_attr in mffg_attrs:
-            attr = deepcopy(mffg_attr)
+        module_id = f'{ciod}-{fg_module_id}'
+        for fg_attr in fg_attrs:
+            attr = deepcopy(fg_attr)
             attr['moduleId'] = module_id
-            attr['path'] = attr['path'].replace(FUNC_GROUP_MODULE_ID, module_id)
+            attr['path'] = attr['path'].replace(fg_module_id, module_id)
             attr_list.append(attr)
     return attr_list
 
@@ -58,11 +65,19 @@ def process_ciod_specific_attributes(module_to_attr, macros, ciod_to_macro, macr
     for rel in ciod_to_macro:
         rel['macroName'] = macro_dict[rel['macroId']]['name']
         macro_attrs = list(filter(lambda r: r['macroId'] == rel['macroId'], macro_to_attr))
-        processed_macro_attrs = process_macro_attributes(macro_attrs, rel)
+        module_type = rel['moduleType']
+        if module_type == 'Multi-frame':
+            processed_macro_attrs = process_mffg_macro_attributes(macro_attrs, rel)
+        elif module_type == 'Current Frame':
+            processed_macro_attrs = process_cffg_macro_attributes(macro_attrs, rel)
+        else:
+            raise Exception(f'Module type property should be either "Multi-frame" or "Current Frame" but is {module_type}')
         ciod_specific_attrs += processed_macro_attrs
-    mffg_attrs = list(filter(lambda r: r['moduleId'] == FUNC_GROUP_MODULE_ID, module_to_attr))
-    ciods_with_macros = list(set([rel['ciodId'] for rel in ciod_to_macro]))
-    ciod_specific_attrs += process_mffg_attributes(ciods_with_macros, mffg_attrs)
+    # Create CIOD-specific versions of each non-macro attribute within the relevant modules
+    ciods_with_mffg_macros = list(set([rel['ciodId'] for rel in ciod_to_macro if rel['moduleType'] == 'Multi-frame']))
+    ciod_specific_attrs += process_fg_attributes(module_to_attr, ciods_with_mffg_macros, MF_FUNC_GROUP_MODULE_ID)
+    ciods_with_cffg_macros = list(set([rel['ciodId'] for rel in ciod_to_macro if rel['moduleType'] == 'Current Frame']))
+    ciod_specific_attrs += process_fg_attributes(module_to_attr, ciods_with_cffg_macros, CF_FUNC_GROUP_MODULE_ID)
     return ciod_specific_attrs
 
 

--- a/dicom_standard/process_ciod_func_group_macro_relationship.py
+++ b/dicom_standard/process_ciod_func_group_macro_relationship.py
@@ -20,18 +20,20 @@ def define_all_relationships(ciod_macro_list):
     for table in ciod_macro_list:
         ciod = table['name']
         macros = table['macros']
-        all_relationships.extend([define_ciod_macro_relationship(ciod, macro)
+        module_type = table['moduleType']
+        all_relationships.extend([define_ciod_macro_relationship(ciod, macro, module_type)
                                   for macro in macros])
     return all_relationships
 
 
-def define_ciod_macro_relationship(ciod, macro):
+def define_ciod_macro_relationship(ciod, macro, module_type):
     usage, conditional_statement = expand_conditional_statement(macro['usage'])
     return {
         "ciodId": pl.create_slug(ciod),
         "macroId": pl.create_slug(clean_macro_name(pl.text_from_html_string(macro['macro']))),
         "usage": usage,
-        "conditionalStatement": conditional_statement
+        "conditionalStatement": conditional_statement,
+        "moduleType": module_type,
     }
 
 

--- a/dicom_standard/process_ciod_module_relationship.py
+++ b/dicom_standard/process_ciod_module_relationship.py
@@ -5,6 +5,7 @@ CIOD-Module relationships defined in the DICOM Standard.
 import sys
 
 from dicom_standard import parse_lib as pl
+from dicom_standard.process_modules import MF_FUNC_GROUP_MODULE_ID, CF_FUNC_GROUP_MODULE_ID
 
 
 def define_all_relationships(ciod_module_list):
@@ -42,8 +43,11 @@ def define_ciod_module_relationship(ciod, module):
         information_entity = 'Image'
     ciod_id = pl.create_slug(ciod)
     module_id = pl.create_slug(pl.text_from_html_string(module['module']))
-    # Add CIOD ID to differentiate "Multi-Frame Functional Group" modules for different CIODs
-    if module_id == 'multi-frame-functional-groups':
+    # Create CIOD-specific "Multi-frame Functional Group" module IDs
+    if module_id == MF_FUNC_GROUP_MODULE_ID:
+        module_id = f'{ciod_id}-{module_id}'
+    # Create CIOD-specific "Current Frame Functional Group" module IDs
+    if module_id == CF_FUNC_GROUP_MODULE_ID:
         module_id = f'{ciod_id}-{module_id}'
     return {
         "ciodId": ciod_id,

--- a/dicom_standard/process_modules.py
+++ b/dicom_standard/process_modules.py
@@ -10,7 +10,8 @@ from operator import itemgetter
 from dicom_standard import parse_lib as pl
 from dicom_standard.macro_utils import MetadataTableType
 
-FUNC_GROUP_MODULE_ID = 'multi-frame-functional-groups'
+MF_FUNC_GROUP_MODULE_ID = 'multi-frame-functional-groups'
+CF_FUNC_GROUP_MODULE_ID = 'current-frame-functional-groups'
 
 
 def modules_from_tables(tables):
@@ -23,11 +24,11 @@ def modules_from_tables(tables):
     return modules
 
 
-def create_ciod_specific_modules(ciods, mffg_module):
+def create_ciod_specific_modules(ciods, module, module_id):
     modules = []
     for ciod in ciods:
-        ciod_specific_module = deepcopy(mffg_module)
-        ciod_specific_module['id'] = f'{ciod}-{FUNC_GROUP_MODULE_ID}'
+        ciod_specific_module = deepcopy(module)
+        ciod_specific_module['id'] = f'{ciod}-{module_id}'
         modules.append(ciod_specific_module)
     return modules
 
@@ -36,9 +37,13 @@ if __name__ == '__main__':
     module_attr_tables = pl.read_json_data(sys.argv[1])
     ciod_to_macro = cast(List[MetadataTableType], pl.read_json_data(sys.argv[2]))
     modules = modules_from_tables(module_attr_tables)
-    ciods_with_macros = list(set([rel['ciodId'] for rel in ciod_to_macro]))
-    multi_frame_func_group_module = next(filter(lambda rel: rel['id'] == FUNC_GROUP_MODULE_ID, modules), None)
-    assert multi_frame_func_group_module is not None, f'Module ID "{FUNC_GROUP_MODULE_ID}" not found in modules.json'
-    ciod_specific_modules = create_ciod_specific_modules(ciods_with_macros, multi_frame_func_group_module)
-    sorted_modules = sorted(modules + ciod_specific_modules, key=itemgetter('id'))
+    ciods_with_mffg_macros = list(set([rel['ciodId'] for rel in ciod_to_macro if rel['moduleType'] == 'Multi-frame']))
+    ciods_with_cffg_macros = list(set([rel['ciodId'] for rel in ciod_to_macro if rel['moduleType'] == 'Current Frame']))
+    multi_frame_func_group_module = next(filter(lambda rel: rel['id'] == MF_FUNC_GROUP_MODULE_ID, modules), None)
+    assert multi_frame_func_group_module is not None, f'Module ID "{MF_FUNC_GROUP_MODULE_ID}" not found'
+    current_frame_func_group_module = next(filter(lambda rel: rel['id'] == CF_FUNC_GROUP_MODULE_ID, modules), None)
+    assert current_frame_func_group_module is not None, f'Module ID "{CF_FUNC_GROUP_MODULE_ID}" not found'
+    ciod_specific_mffg_modules = create_ciod_specific_modules(ciods_with_mffg_macros, multi_frame_func_group_module, MF_FUNC_GROUP_MODULE_ID)
+    ciod_specific_cffg_modules = create_ciod_specific_modules(ciods_with_cffg_macros, current_frame_func_group_module, CF_FUNC_GROUP_MODULE_ID)
+    sorted_modules = sorted(modules + ciod_specific_mffg_modules + ciod_specific_cffg_modules, key=itemgetter('id'))
     pl.write_pretty_json(sorted_modules)

--- a/dicom_standard/table_utils.py
+++ b/dicom_standard/table_utils.py
@@ -58,9 +58,9 @@ def get_short_standard_link(tdiv: Tag) -> str:
 def get_table_description(tdiv: Tag) -> Optional[Tag]:
     section = tdiv.parent.parent
     # Some descriptions are children of 'h3' tags while others are children of 'h5' tags
-    description_title = section.find(['h3', 'h5'], class_='title')
-    assert description_title is not None, 'Table description not found.'
-    return description_title.parent.parent.parent.parent.p
+    section_header = section.find(['h3', 'h5'], class_='title')
+    assert section_header is not None, 'Section header not found.'
+    return section_header.parent.parent.parent.parent.p
 
 
 def table_to_dict(table: TableListType, row_names: List[str], omit_empty: bool = False) -> List[TableDictType]:

--- a/standard/ciod_to_func_group_macros.json
+++ b/standard/ciod_to_func_group_macros.json
@@ -3,2370 +3,2765 @@
         "ciodId":"multi-frame-grayscale-byte-sc-image",
         "macroId":"pixel-measures",
         "usage":"C",
-        "conditionalStatement":"Required if Plane Position (Patient) or Plane Orientation (Patient) Macros Present"
+        "conditionalStatement":"Required if Plane Position (Patient) or Plane Orientation (Patient) Macros Present",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"multi-frame-grayscale-byte-sc-image",
         "macroId":"plane-position-patient",
         "usage":"C",
-        "conditionalStatement":"Required if Pixel Measures or Plane Orientation (Patient) Macros Present"
+        "conditionalStatement":"Required if Pixel Measures or Plane Orientation (Patient) Macros Present",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"multi-frame-grayscale-byte-sc-image",
         "macroId":"plane-orientation-patient",
         "usage":"C",
-        "conditionalStatement":"Required if Pixel Measures or Plane Position (Patient) Macros Present"
+        "conditionalStatement":"Required if Pixel Measures or Plane Position (Patient) Macros Present",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"multi-frame-grayscale-word-sc-image",
         "macroId":"pixel-measures",
         "usage":"C",
-        "conditionalStatement":"Required if Plane Position (Patient) or Plane Orientation (Patient) Macros Present"
+        "conditionalStatement":"Required if Plane Position (Patient) or Plane Orientation (Patient) Macros Present",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"multi-frame-grayscale-word-sc-image",
         "macroId":"plane-position-patient",
         "usage":"C",
-        "conditionalStatement":"Required if Pixel Measures or Plane Orientation (Patient) Macros Present"
+        "conditionalStatement":"Required if Pixel Measures or Plane Orientation (Patient) Macros Present",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"multi-frame-grayscale-word-sc-image",
         "macroId":"plane-orientation-patient",
         "usage":"C",
-        "conditionalStatement":"Required if Pixel Measures or Plane Position (Patient) Macros Present"
+        "conditionalStatement":"Required if Pixel Measures or Plane Position (Patient) Macros Present",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"multi-frame-true-color-sc-image",
         "macroId":"pixel-measures",
         "usage":"C",
-        "conditionalStatement":"Required if Plane Position (Patient) or Plane Orientation (Patient) Macros Present"
+        "conditionalStatement":"Required if Plane Position (Patient) or Plane Orientation (Patient) Macros Present",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"multi-frame-true-color-sc-image",
         "macroId":"plane-position-patient",
         "usage":"C",
-        "conditionalStatement":"Required if Pixel Measures or Plane Orientation (Patient) Macros Present"
+        "conditionalStatement":"Required if Pixel Measures or Plane Orientation (Patient) Macros Present",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"multi-frame-true-color-sc-image",
         "macroId":"plane-orientation-patient",
         "usage":"C",
-        "conditionalStatement":"Required if Pixel Measures or Plane Position (Patient) Macros Present"
+        "conditionalStatement":"Required if Pixel Measures or Plane Position (Patient) Macros Present",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"vl-whole-slide-microscopy-image",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"vl-whole-slide-microscopy-image",
         "macroId":"frame-content",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"vl-whole-slide-microscopy-image",
         "macroId":"referenced-image",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"vl-whole-slide-microscopy-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance."
+        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"vl-whole-slide-microscopy-image",
         "macroId":"real-world-value-mapping",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"vl-whole-slide-microscopy-image",
         "macroId":"plane-position-slide",
         "usage":"C",
-        "conditionalStatement":"Required if Dimension Organization Type (0020,9311) is not TILED_FULL; may be present otherwise."
+        "conditionalStatement":"Required if Dimension Organization Type (0020,9311) is not TILED_FULL; may be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"vl-whole-slide-microscopy-image",
         "macroId":"optical-path-identification",
         "usage":"C",
-        "conditionalStatement":"Required if Dimension Organization Type (0020,9311) is not TILED_FULL; may be present otherwise."
+        "conditionalStatement":"Required if Dimension Organization Type (0020,9311) is not TILED_FULL; may be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"vl-whole-slide-microscopy-image",
         "macroId":"specimen-reference",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"vl-whole-slide-microscopy-image",
         "macroId":"whole-slide-microscopy-image-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"real-time-video-endoscopic-image",
         "macroId":"time-of-frame",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Current Frame"
     },
     {
         "ciodId":"real-time-video-endoscopic-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Current Frame"
     },
     {
         "ciodId":"real-time-video-endoscopic-image",
         "macroId":"frame-usefulness",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Current Frame"
     },
     {
         "ciodId":"real-time-video-endoscopic-image",
         "macroId":"camera-position",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Current Frame"
     },
     {
         "ciodId":"real-time-video-photographic-image",
         "macroId":"time-of-frame",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Current Frame"
     },
     {
         "ciodId":"real-time-video-photographic-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Current Frame"
     },
     {
         "ciodId":"real-time-video-photographic-image",
         "macroId":"frame-usefulness",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Current Frame"
     },
     {
         "ciodId":"real-time-video-photographic-image",
         "macroId":"camera-position",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Current Frame"
     },
     {
         "ciodId":"real-time-audio-waveform",
         "macroId":"time-of-frame",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Current Frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"plane-position-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"plane-orientation-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"referenced-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been planned on another image or frame. May be present otherwise"
+        "conditionalStatement":"Required if the image or frame has been planned on another image or frame. May be present otherwise",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance."
+        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"cardiac-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"pixel-value-transformation",
         "usage":"C",
-        "conditionalStatement":"Required if Photometric Interpretation (0028,0004) is MONOCHROME2."
+        "conditionalStatement":"Required if Photometric Interpretation (0028,0004) is MONOCHROME2.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"frame-voi-lut",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"real-world-value-mapping",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"contrast-bolus-usage",
         "usage":"C",
-        "conditionalStatement":"Required if Contrast/Bolus Agent Sequence (0018,0012) is used."
+        "conditionalStatement":"Required if Contrast/Bolus Agent Sequence (0018,0012) is used.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"respiratory-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Respiratory Motion Compensation Technique (0018,9170) equals other than NONE, REALTIME or BREATH_HOLD and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Respiratory Motion Compensation Technique (0018,9170) equals other than NONE, REALTIME or BREATH_HOLD and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-image-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-timing-and-related-parameters",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-fov-geometry",
         "usage":"C",
-        "conditionalStatement":"Required if Geometry of k-Space Traversal (0018,9032) equals RECTILINEAR and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Geometry of k-Space Traversal (0018,9032) equals RECTILINEAR and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-echo",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-modifier",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-imaging-modifier",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-receive-coil",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-transmit-coil",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-diffusion",
         "usage":"C",
-        "conditionalStatement":"Required if Acquisition Contrast (0008,9209) in any MR Image Frame Type Functional Group in the SOP Instance equals DIFFUSION and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Acquisition Contrast (0008,9209) in any MR Image Frame Type Functional Group in the SOP Instance equals DIFFUSION and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-averages",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-spatial-saturation",
         "usage":"C",
-        "conditionalStatement":"Required if Spatial Pre-saturation (0018,9027) equals SLAB for any frame in the SOP Instance and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Spatial Pre-saturation (0018,9027) equals SLAB for any frame in the SOP Instance and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-metabolite-map",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 3 equals METABOLITE_MAP. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 3 equals METABOLITE_MAP. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-velocity-encoding",
         "usage":"C",
-        "conditionalStatement":"Required if Phase Contrast (0018,9014) equals YES and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Phase Contrast (0018,9014) equals YES and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"mr-arterial-spin-labeling",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 3 is ASL. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 3 is ASL. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"functional-mr",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-image",
         "macroId":"temporal-position",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"plane-position-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"plane-orientation-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"referenced-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been planned on another image or frame. May be present otherwise"
+        "conditionalStatement":"Required if the image or frame has been planned on another image or frame. May be present otherwise",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance."
+        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"cardiac-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"contrast-bolus-usage",
         "usage":"C",
-        "conditionalStatement":"Required if Contrast/Bolus Agent Sequence (0018,0012) is used."
+        "conditionalStatement":"Required if Contrast/Bolus Agent Sequence (0018,0012) is used.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"respiratory-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Respiratory Motion Compensation Technique (0018,9170) equals other than NONE, REALTIME or BREATH_HOLD and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Respiratory Motion Compensation Technique (0018,9170) equals other than NONE, REALTIME or BREATH_HOLD and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"mr-spectroscopy-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"mr-timing-and-related-parameters",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"mr-spectroscopy-fov-geometry",
         "usage":"C",
-        "conditionalStatement":"Required if Geometry of k-Space Traversal (0018,9032) equals RECTILINEAR and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Geometry of k-Space Traversal (0018,9032) equals RECTILINEAR and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"mr-echo",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"mr-modifier",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"mr-receive-coil",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"mr-transmit-coil",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"mr-diffusion",
         "usage":"C",
-        "conditionalStatement":"Required if Acquisition Contrast (0008,9209) in any MR Image Frame Type Functional Group in the SOP Instance equals DIFFUSION and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Acquisition Contrast (0008,9209) in any MR Image Frame Type Functional Group in the SOP Instance equals DIFFUSION and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"mr-averages",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"mr-spatial-saturation",
         "usage":"C",
-        "conditionalStatement":"Required if Spatial Pre-saturation (0018,9027) equals SLAB for any frame in the SOP Instance and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Spatial Pre-saturation (0018,9027) equals SLAB for any frame in the SOP Instance and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"mr-velocity-encoding",
         "usage":"C",
-        "conditionalStatement":"Required if Phase Contrast (0018,9014) equals YES and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Phase Contrast (0018,9014) equals YES and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"mr-spectroscopy",
         "macroId":"temporal-position",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"plane-position-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"plane-orientation-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"referenced-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been planned on another image or frame, may be present otherwise."
+        "conditionalStatement":"Required if the image or frame has been planned on another image or frame, may be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance."
+        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"cardiac-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"frame-voi-lut",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"real-world-value-mapping",
         "usage":"C",
-        "conditionalStatement":"Required if Multi-energy CT Acquisition (0018,9361) is YES. May be present otherwise."
+        "conditionalStatement":"Required if Multi-energy CT Acquisition (0018,9361) is YES. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"contrast-bolus-usage",
         "usage":"C",
-        "conditionalStatement":"Required if Contrast/Bolus Agent Sequence (0018,0012) is used."
+        "conditionalStatement":"Required if Contrast/Bolus Agent Sequence (0018,0012) is used.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"respiratory-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Respiratory Motion Compensation Technique (0018,9170) equals other than NONE, REALTIME or BREATH_HOLD and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Respiratory Motion Compensation Technique (0018,9170) equals other than NONE, REALTIME or BREATH_HOLD and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"irradiation-event-identification",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"ct-image-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"ct-acquisition-type",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"ct-acquisition-details",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"ct-table-dynamics",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"ct-position",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise"
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"ct-geometry",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"ct-reconstruction",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED and Acquisition Type (0018,9302) is other than CONSTANT_ANGLE, may be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED and Acquisition Type (0018,9302) is other than CONSTANT_ANGLE, may be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"ct-exposure",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"ct-x-ray-details",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED, may be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"ct-pixel-value-transformation",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"ct-additional-x-ray-source",
         "usage":"C",
-        "conditionalStatement":"Required if the image is reconstructed from a system with multiple X-Ray sources."
+        "conditionalStatement":"Required if the image is reconstructed from a system with multiple X-Ray sources.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"multi-energy-ct-processing",
         "usage":"C",
-        "conditionalStatement":"Required if the image pixel data contains the results of Multi-energy material processing."
+        "conditionalStatement":"Required if the image pixel data contains the results of Multi-energy material processing.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"multi-energy-ct-characteristics",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-ct-image",
         "macroId":"temporal-position",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"referenced-image",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance."
+        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"cardiac-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"frame-voi-lut",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"contrast-bolus-usage",
         "usage":"C",
-        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present."
+        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"pixel-intensity-relationship-lut",
         "usage":"C",
-        "conditionalStatement":"Required if Pixel Intensity Relationship (0028,1040) equals LOG. May be present otherwise."
+        "conditionalStatement":"Required if Pixel Intensity Relationship (0028,1040) equals LOG. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"frame-pixel-shift",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"patient-orientation-in-frame",
         "usage":"C",
-        "conditionalStatement":"Required if C-arm Positioner Tabletop Relationship (0018,9474) is present and equals YES. May be present otherwise."
+        "conditionalStatement":"Required if C-arm Positioner Tabletop Relationship (0018,9474) is present and equals YES. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"frame-display-shutter",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"respiratory-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"irradiation-event-identification",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-frame-characteristics",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-field-of-view",
         "usage":"C",
-        "conditionalStatement":"Required if Isocenter Reference System Sequence (0018,9462) is present. May be present otherwise."
+        "conditionalStatement":"Required if Isocenter Reference System Sequence (0018,9462) is present. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-exposure-control-sensing-regions",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-frame-pixel-data-properties",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-frame-detector-parameters",
         "usage":"C",
-        "conditionalStatement":"Required if X-Ray Receptor Type (0018,9420) is present and equals DIGITAL_DETECTOR."
+        "conditionalStatement":"Required if X-Ray Receptor Type (0018,9420) is present and equals DIGITAL_DETECTOR.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-calibration-device-usage",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-object-thickness",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-frame-acquisition",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-projection-pixel-calibration",
         "usage":"C",
-        "conditionalStatement":"Required if C-arm Positioner Tabletop Relationship (0018,9474) is present and equals YES."
+        "conditionalStatement":"Required if C-arm Positioner Tabletop Relationship (0018,9474) is present and equals YES.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-positioner",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL and C-arm Positioner Tabletop Relationship (0018,9474) is present and equals YES. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL and C-arm Positioner Tabletop Relationship (0018,9474) is present and equals YES. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-table-position",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL and C-arm Positioner Tabletop Relationship (0018,9474) is present and equals YES. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL and C-arm Positioner Tabletop Relationship (0018,9474) is present and equals YES. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-collimator",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-isocenter-reference-system",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xa-image",
         "macroId":"x-ray-geometry",
         "usage":"C",
-        "conditionalStatement":"Required if Projection Pixel Calibration Sequence (0018,9401) is present. May be present otherwise."
+        "conditionalStatement":"Required if Projection Pixel Calibration Sequence (0018,9401) is present. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"referenced-image",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance."
+        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"cardiac-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"frame-voi-lut",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"contrast-bolus-usage",
         "usage":"C",
-        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present."
+        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"pixel-intensity-relationship-lut",
         "usage":"C",
-        "conditionalStatement":"Required if Pixel Intensity Relationship (0028,1040) equals LOG. May be present otherwise."
+        "conditionalStatement":"Required if Pixel Intensity Relationship (0028,1040) equals LOG. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"frame-pixel-shift",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"patient-orientation-in-frame",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"frame-display-shutter",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"respiratory-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"irradiation-event-identification",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"x-ray-frame-characteristics",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"x-ray-field-of-view",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"x-ray-exposure-control-sensing-regions",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"x-ray-frame-pixel-data-properties",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"x-ray-frame-detector-parameters",
         "usage":"C",
-        "conditionalStatement":"Required if X-Ray Receptor Type (0018,9420) is present and equals DIGITAL_DETECTOR."
+        "conditionalStatement":"Required if X-Ray Receptor Type (0018,9420) is present and equals DIGITAL_DETECTOR.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"x-ray-calibration-device-usage",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"x-ray-object-thickness",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"x-ray-frame-acquisition",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"x-ray-positioner",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"x-ray-table-position",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"x-ray-collimator",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-xrf-image",
         "macroId":"x-ray-geometry",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"segmentation",
         "macroId":"pixel-measures",
         "usage":"C",
-        "conditionalStatement":"Required if Derivation Image Functional Group (C.7.6.16.2.6) is not present and the Frame of Reference is defined in the patient-relative Reference Coordinate System. May be present otherwise if the Frame of Reference is defined in the patient-relative Reference Coordinate System. See Section\u00a0A.51.5.1"
+        "conditionalStatement":"Required if Derivation Image Functional Group (C.7.6.16.2.6) is not present and the Frame of Reference is defined in the patient-relative Reference Coordinate System. May be present otherwise if the Frame of Reference is defined in the patient-relative Reference Coordinate System. See Section\u00a0A.51.5.1",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"segmentation",
         "macroId":"plane-position-patient",
         "usage":"C",
-        "conditionalStatement":"Required if Derivation Image Functional Group (C.7.6.16.2.6) is not present and the Frame of Reference is defined in the patient-relative Reference Coordinate System. May be present otherwise if the Frame of Reference is defined in the patient-relative Reference Coordinate System. See Section\u00a0A.51.5.1"
+        "conditionalStatement":"Required if Derivation Image Functional Group (C.7.6.16.2.6) is not present and the Frame of Reference is defined in the patient-relative Reference Coordinate System. May be present otherwise if the Frame of Reference is defined in the patient-relative Reference Coordinate System. See Section\u00a0A.51.5.1",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"segmentation",
         "macroId":"plane-orientation-patient",
         "usage":"C",
-        "conditionalStatement":"Required if Derivation Image Functional Group (C.7.6.16.2.6) is not present. May be present otherwise. See Section\u00a0A.51.5.1"
+        "conditionalStatement":"Required if Derivation Image Functional Group (C.7.6.16.2.6) is not present. May be present otherwise. See Section\u00a0A.51.5.1",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"segmentation",
         "macroId":"plane-position-slide",
         "usage":"C",
-        "conditionalStatement":"Required if Derivation Image Functional Group (C.7.6.16.2.6) is not present and the Frame of Reference is defined in the Slide Coordinate System. May be present otherwise if the Frame of Reference is defined in the Slide Coordinate System. See Section\u00a0A.51.5.1."
+        "conditionalStatement":"Required if Derivation Image Functional Group (C.7.6.16.2.6) is not present and the Frame of Reference is defined in the Slide Coordinate System. May be present otherwise if the Frame of Reference is defined in the Slide Coordinate System. See Section\u00a0A.51.5.1.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"segmentation",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if Pixel Measures (C.7.6.16.2.1) or either Plane Position (Patient) (C.7.6.16.2.3) or Plane Orientation (Patient) (C.7.6.16.2.4) (if the Frame of Reference is defined in the patient-relative Reference Coordinate System), or Plane Position (Slide) (C.8.12.6.1) (if the Frame of Reference is defined in the Slide Coordinate System) Functional Groups are not present. May be present otherwise. See Section\u00a0A.51.5.1"
+        "conditionalStatement":"Required if Pixel Measures (C.7.6.16.2.1) or either Plane Position (Patient) (C.7.6.16.2.3) or Plane Orientation (Patient) (C.7.6.16.2.4) (if the Frame of Reference is defined in the patient-relative Reference Coordinate System), or Plane Position (Slide) (C.8.12.6.1) (if the Frame of Reference is defined in the Slide Coordinate System) Functional Groups are not present. May be present otherwise. See Section\u00a0A.51.5.1",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"segmentation",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"segmentation",
         "macroId":"segmentation",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-tomography-image",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-tomography-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-tomography-image",
         "macroId":"plane-position-patient",
         "usage":"C",
-        "conditionalStatement":"Required if no Ophthalmic Photography Reference Image is available or if Ophthalmic Volumetric Properties Flag (0022,1622) is YES; May be present otherwise"
+        "conditionalStatement":"Required if no Ophthalmic Photography Reference Image is available or if Ophthalmic Volumetric Properties Flag (0022,1622) is YES; May be present otherwise",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-tomography-image",
         "macroId":"plane-orientation-patient",
         "usage":"C",
-        "conditionalStatement":"Required if no Ophthalmic Photography Reference Image is available or if Ophthalmic Volumetric Properties Flag (0022,1622) is YES; May be present otherwise"
+        "conditionalStatement":"Required if no Ophthalmic Photography Reference Image is available or if Ophthalmic Volumetric Properties Flag (0022,1622) is YES; May be present otherwise",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-tomography-image",
         "macroId":"referenced-image",
         "usage":"C",
-        "conditionalStatement":"Required if Ophthalmic Photography Reference Image is available."
+        "conditionalStatement":"Required if Ophthalmic Photography Reference Image is available.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-tomography-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance."
+        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-tomography-image",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-tomography-image",
         "macroId":"cardiac-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE. May be present otherwise."
+        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-tomography-image",
         "macroId":"contrast-bolus-usage",
         "usage":"C",
-        "conditionalStatement":"Required if Contrast/Bolus Agent Sequence (0018,0012) is used. May not be used as a Shared Functional Group"
+        "conditionalStatement":"Required if Contrast/Bolus Agent Sequence (0018,0012) is used. May not be used as a Shared Functional Group",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-tomography-image",
         "macroId":"ophthalmic-frame-location",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"plane-position-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"plane-orientation-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"referenced-image",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals DERIVED."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals DERIVED.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"cardiac-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"pixel-value-transformation",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"frame-voi-lut",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"real-world-value-mapping",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"contrast-bolus-usage",
         "usage":"C",
-        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present."
+        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"respiratory-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-angiographic-image",
         "macroId":"x-ray-3d-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-craniofacial-image",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-craniofacial-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-craniofacial-image",
         "macroId":"plane-position-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-craniofacial-image",
         "macroId":"plane-orientation-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-craniofacial-image",
         "macroId":"referenced-image",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-craniofacial-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals DERIVED."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals DERIVED.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-craniofacial-image",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-craniofacial-image",
         "macroId":"pixel-value-transformation",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-craniofacial-image",
         "macroId":"frame-voi-lut",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-craniofacial-image",
         "macroId":"real-world-value-mapping",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-craniofacial-image",
         "macroId":"contrast-bolus-usage",
         "usage":"C",
-        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present."
+        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"x-ray-3d-craniofacial-image",
         "macroId":"x-ray-3d-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"plane-position-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"plane-orientation-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"referenced-image",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals DERIVED."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals DERIVED.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"identity-pixel-value-transformation",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"frame-voi-lut-with-lut",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"real-world-value-mapping",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"contrast-bolus-usage",
         "usage":"C",
-        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present."
+        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"x-ray-3d-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-tomosynthesis-image",
         "macroId":"breast-biopsy-target",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"plane-position-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"plane-orientation-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"referenced-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been planned on another image or frame, may be present otherwise."
+        "conditionalStatement":"Required if the image or frame has been planned on another image or frame, may be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance."
+        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"pixel-value-transformation",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"frame-voi-lut",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"real-world-value-mapping",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"cardiac-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE. May be present otherwise."
+        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"respiratory-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Respiratory Motion Compensation Technique (0018,9170) equals other than NONE. May be present otherwise."
+        "conditionalStatement":"Required if Respiratory Motion Compensation Technique (0018,9170) equals other than NONE. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"radiopharmaceutical-usage",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"patient-physiological-state",
         "usage":"C",
-        "conditionalStatement":"Required for cardiac rest and stress images."
+        "conditionalStatement":"Required for cardiac rest and stress images.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"pet-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"pet-frame-acquisition",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"pet-detector-motion-details",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL and Type of Detector Motion (0054,0202) is not equal to STATIONARY."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL and Type of Detector Motion (0054,0202) is not equal to STATIONARY.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"pet-position",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"pet-frame-correction-factors",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"pet-reconstruction",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-pet-image",
         "macroId":"pet-table-dynamics",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL and Table Motion (0018,1134) is equal to DYNAMIC."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 equals ORIGINAL and Table Motion (0018,1134) is equal to DYNAMIC.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"plane-position-patient",
         "usage":"C",
-        "conditionalStatement":"Required if Ultrasound Acquisition Geometry (0020,9307) has a value of PATIENT. May be present otherwise. See Section\u00a0A.59.4.1.2."
+        "conditionalStatement":"Required if Ultrasound Acquisition Geometry (0020,9307) has a value of PATIENT. May be present otherwise. See Section\u00a0A.59.4.1.2.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"plane-orientation-patient",
         "usage":"C",
-        "conditionalStatement":"Required if Ultrasound Acquisition Geometry (0020,9307) has a value of PATIENT. May be present otherwise. See Section\u00a0A.59.4.1.2."
+        "conditionalStatement":"Required if Ultrasound Acquisition Geometry (0020,9307) has a value of PATIENT. May be present otherwise. See Section\u00a0A.59.4.1.2.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"referenced-image",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance."
+        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"cardiac-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Cardiac Synchronization is used"
+        "conditionalStatement":"Required if Cardiac Synchronization is used",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"frame-voi-lut",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"real-world-value-mapping",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"contrast-bolus-usage",
         "usage":"C",
-        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present."
+        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"patient-orientation-in-frame",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"frame-display-shutter",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"respiratory-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Respiratory Synchronization is used"
+        "conditionalStatement":"Required if Respiratory Synchronization is used",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"plane-position-volume",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"plane-orientation-volume",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"temporal-position",
         "usage":"C",
-        "conditionalStatement":"Required if frames are temporally related and not temporally referenced to a Cardiac or Respiratory event"
+        "conditionalStatement":"Required if frames are temporally related and not temporally referenced to a Cardiac or Respiratory event",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"image-data-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-us-volume",
         "macroId":"us-image-description",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"intravascular-optical-coherence-tomography-image",
         "macroId":"pixel-measures",
         "usage":"C",
-        "conditionalStatement":"Required if Presentation Intent Type (0008,0068) is FOR PRESENTATION."
+        "conditionalStatement":"Required if Presentation Intent Type (0008,0068) is FOR PRESENTATION.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"intravascular-optical-coherence-tomography-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"intravascular-optical-coherence-tomography-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance."
+        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"intravascular-optical-coherence-tomography-image",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"intravascular-optical-coherence-tomography-image",
         "macroId":"cardiac-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE May be present otherwise."
+        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"intravascular-optical-coherence-tomography-image",
         "macroId":"frame-voi-lut",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"intravascular-optical-coherence-tomography-image",
         "macroId":"pixel-intensity-relationship-lut",
         "usage":"C",
-        "conditionalStatement":"Required if Pixel Intensity Relationship (0028,1040) equals LOG. May be present otherwise."
+        "conditionalStatement":"Required if Pixel Intensity Relationship (0028,1040) equals LOG. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"intravascular-optical-coherence-tomography-image",
         "macroId":"intravascular-oct-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"intravascular-optical-coherence-tomography-image",
         "macroId":"intravascular-frame-content",
         "usage":"C",
-        "conditionalStatement":"Required if Intravascular Acquisition (0018,3100) equals MEASURED or Presentation Intent Type (0008,0068) equals FORPRESENTATION."
+        "conditionalStatement":"Required if Intravascular Acquisition (0018,3100) equals MEASURED or Presentation Intent Type (0008,0068) equals FORPRESENTATION.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"intravascular-optical-coherence-tomography-image",
         "macroId":"intravascular-oct-frame-content",
         "usage":"C",
-        "conditionalStatement":"Required if Presentation Intent Type (0008,0068) equals FOR PROCESSING."
+        "conditionalStatement":"Required if Presentation Intent Type (0008,0068) equals FOR PROCESSING.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"plane-position-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"plane-orientation-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"referenced-image",
         "usage":"C",
-        "conditionalStatement":"Required if Referenced Image Sequence (0008,1140) was present in any of the Classic Images that were converted."
+        "conditionalStatement":"Required if Referenced Image Sequence (0008,1140) was present in any of the Classic Images that were converted.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if Source Image Sequence (0008,2112) was present in any of the Classic Images that were converted."
+        "conditionalStatement":"Required if Source Image Sequence (0008,2112) was present in any of the Classic Images that were converted.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"cardiac-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"frame-anatomy",
         "usage":"C",
-        "conditionalStatement":"Required if Body Part Examined (0018,0015) is present and contains a value defined in Annex L \u201cCorrespondence of Anatomic Region Codes and Body Part Examined Defined Terms\u201d in PS3.16, or Anatomic Region Sequence (0008,2218) was present in any of the Classic Images that were converted."
+        "conditionalStatement":"Required if Body Part Examined (0018,0015) is present and contains a value defined in Annex L \u201cCorrespondence of Anatomic Region Codes and Body Part Examined Defined Terms\u201d in PS3.16, or Anatomic Region Sequence (0008,2218) was present in any of the Classic Images that were converted.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"frame-voi-lut",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"contrast-bolus-usage",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"respiratory-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"irradiation-event-identification",
         "usage":"C",
-        "conditionalStatement":"Required if Irradiation Event UID (0008,3010) was present in any of the Classic Images that were converted."
+        "conditionalStatement":"Required if Irradiation Event UID (0008,3010) was present in any of the Classic Images that were converted.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"ct-image-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"ct-pixel-value-transformation",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"temporal-position",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"unassigned-shared-converted-attributes",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"unassigned-per-frame-converted-attributes",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-ct-image",
         "macroId":"image-frame-conversion-source",
         "usage":"C",
-        "conditionalStatement":"Required if created by conversion from a DICOM source; may not be used as a Shared Functional Group"
+        "conditionalStatement":"Required if created by conversion from a DICOM source; may not be used as a Shared Functional Group",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"plane-position-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"plane-orientation-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"referenced-image",
         "usage":"C",
-        "conditionalStatement":"Required if Referenced Image Sequence (0008,1140) was present in any of the Classic Images that were converted."
+        "conditionalStatement":"Required if Referenced Image Sequence (0008,1140) was present in any of the Classic Images that were converted.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if Source Image Sequence (0008,2112) was present in any of the Classic Images that were converted."
+        "conditionalStatement":"Required if Source Image Sequence (0008,2112) was present in any of the Classic Images that were converted.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"cardiac-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"frame-anatomy",
         "usage":"C",
-        "conditionalStatement":"Required if Body Part Examined (0018,0015) is present and contains a value defined in Annex L \u201cCorrespondence of Anatomic Region Codes and Body Part Examined Defined Terms\u201d in PS3.16, or Anatomic Region Sequence (0008,2218) was present in any of the Classic Images that were converted."
+        "conditionalStatement":"Required if Body Part Examined (0018,0015) is present and contains a value defined in Annex L \u201cCorrespondence of Anatomic Region Codes and Body Part Examined Defined Terms\u201d in PS3.16, or Anatomic Region Sequence (0008,2218) was present in any of the Classic Images that were converted.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"pixel-value-transformation",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"frame-voi-lut",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"real-world-value-mapping",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"contrast-bolus-usage",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"respiratory-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"mr-image-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"temporal-position",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"unassigned-shared-converted-attributes",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"unassigned-per-frame-converted-attributes",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-mr-image",
         "macroId":"image-frame-conversion-source",
         "usage":"C",
-        "conditionalStatement":"Required if created by conversion from a DICOM source; may not be used as a Shared Functional Group"
+        "conditionalStatement":"Required if created by conversion from a DICOM source; may not be used as a Shared Functional Group",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"plane-position-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"plane-orientation-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"referenced-image",
         "usage":"C",
-        "conditionalStatement":"Required if Referenced Image Sequence (0008,1140) was present in any of the Classic Images that were converted."
+        "conditionalStatement":"Required if Referenced Image Sequence (0008,1140) was present in any of the Classic Images that were converted.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if Source Image Sequence (0008,2112) was present in any of the Classic Images that were converted."
+        "conditionalStatement":"Required if Source Image Sequence (0008,2112) was present in any of the Classic Images that were converted.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"cardiac-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"frame-anatomy",
         "usage":"C",
-        "conditionalStatement":"Required if Body Part Examined (0018,0015) is present and contains a value defined in Annex L \u201cCorrespondence of Anatomic Region Codes and Body Part Examined Defined Terms\u201d in PS3.16, or Anatomic Region Sequence (0008,2218) was present in any of the Classic Images that were converted."
+        "conditionalStatement":"Required if Body Part Examined (0018,0015) is present and contains a value defined in Annex L \u201cCorrespondence of Anatomic Region Codes and Body Part Examined Defined Terms\u201d in PS3.16, or Anatomic Region Sequence (0008,2218) was present in any of the Classic Images that were converted.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"pixel-value-transformation",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"frame-voi-lut",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"real-world-value-mapping",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"respiratory-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"irradiation-event-identification",
         "usage":"C",
-        "conditionalStatement":"Required if Irradiation Event UID (0008,3010) was present in any of the Classic Images that were converted."
+        "conditionalStatement":"Required if Irradiation Event UID (0008,3010) was present in any of the Classic Images that were converted.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"pet-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"temporal-position",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"unassigned-shared-converted-attributes",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"unassigned-per-frame-converted-attributes",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"legacy-converted-enhanced-pet-image",
         "macroId":"image-frame-conversion-source",
         "usage":"C",
-        "conditionalStatement":"Required if created by conversion from a DICOM source; may not be used as a Shared Functional Group"
+        "conditionalStatement":"Required if created by conversion from a DICOM source; may not be used as a Shared Functional Group",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"referenced-image",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the Image Type (0008,0008) Value 1 equals DERIVED or Value 1 is ORIGINAL and Presentation Intent Type equals FOR PRESENTATION. May be present otherwise."
+        "conditionalStatement":"Required if the Image Type (0008,0008) Value 1 equals DERIVED or Value 1 is ORIGINAL and Presentation Intent Type equals FOR PRESENTATION. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"identity-pixel-value-transformation",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"frame-voi-lut-with-lut",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"contrast-bolus-usage",
         "usage":"C",
-        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present."
+        "conditionalStatement":"Required if the Enhanced Contrast/Bolus Module is present.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"frame-display-shutter",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"irradiation-event-identification",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"x-ray-frame-characteristics",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"x-ray-field-of-view",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"x-ray-frame-pixel-data-properties",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"x-ray-frame-detector-parameters",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"x-ray-calibration-device-usage",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"x-ray-frame-acquisition",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"x-ray-collimator",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"breast-x-ray-positioner",
         "usage":"C",
-        "conditionalStatement":"Required if X-Ray Source moves relative to the Patient. May be present otherwise."
+        "conditionalStatement":"Required if X-Ray Source moves relative to the Patient. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"breast-x-ray-detector",
         "usage":"C",
-        "conditionalStatement":"Required if X-Ray Detector plane is not normal to the X-Ray beam vector. May be present otherwise."
+        "conditionalStatement":"Required if X-Ray Detector plane is not normal to the X-Ray beam vector. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"breast-x-ray-geometry",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"breast-x-ray-acquisition-dose",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"breast-x-ray-isocenter-reference-system",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"x-ray-grid",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"breast-projection-x-ray-image",
         "macroId":"x-ray-filter",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"plane-position-patient",
         "usage":"C",
-        "conditionalStatement":"\u2013 Required if the Frame of Reference is defined in the patient-relative Reference Coordinate System."
+        "conditionalStatement":"\u2013 Required if the Frame of Reference is defined in the patient-relative Reference Coordinate System.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"plane-orientation-patient",
         "usage":"C",
-        "conditionalStatement":"\u2013 Required if the Frame of Reference is defined in the patient-relative Reference Coordinate System."
+        "conditionalStatement":"\u2013 Required if the Frame of Reference is defined in the patient-relative Reference Coordinate System.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"plane-position-slide",
         "usage":"C",
-        "conditionalStatement":"Required if the Frame of Reference is defined in the Slide Coordinate System."
+        "conditionalStatement":"Required if the Frame of Reference is defined in the Slide Coordinate System.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"referenced-image",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance."
+        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"cardiac-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"identity-pixel-value-transformation",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"frame-voi-lut-with-lut",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"real-world-value-mapping",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"contrast-bolus-usage",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"respiratory-synchronization",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"stored-value-color-range",
         "usage":"C",
-        "conditionalStatement":"Required if Pixel Presentation (0008,9205) in the Parametric Map Image Module equals COLOR_RANGE."
+        "conditionalStatement":"Required if Pixel Presentation (0008,9205) in the Parametric Map Image Module equals COLOR_RANGE.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"parametric-map-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"unassigned-shared-converted-attributes",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"parametric-map",
         "macroId":"unassigned-per-frame-converted-attributes",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-optical-coherence-tomography-b-scan-volume-analysis",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-optical-coherence-tomography-b-scan-volume-analysis",
         "macroId":"plane-orientation-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-optical-coherence-tomography-b-scan-volume-analysis",
         "macroId":"plane-position-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-optical-coherence-tomography-b-scan-volume-analysis",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-optical-coherence-tomography-b-scan-volume-analysis",
         "macroId":"referenced-image",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-optical-coherence-tomography-b-scan-volume-analysis",
         "macroId":"derivation-image",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-optical-coherence-tomography-b-scan-volume-analysis",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-optical-coherence-tomography-b-scan-volume-analysis",
         "macroId":"frame-voi-lut-with-lut",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"ophthalmic-optical-coherence-tomography-b-scan-volume-analysis",
         "macroId":"real-world-value-mapping",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"pixel-measures",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"frame-content",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"plane-position-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"plane-orientation-patient",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"referenced-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been planned on another image or frame. May be present otherwise"
+        "conditionalStatement":"Required if the image or frame has been planned on another image or frame. May be present otherwise",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"derivation-image",
         "usage":"C",
-        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance."
+        "conditionalStatement":"Required if the image or frame has been derived from another SOP Instance.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"cardiac-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Cardiac Synchronization Technique (0018,9037) equals other than NONE and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"frame-anatomy",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"pixel-value-transformation",
         "usage":"C",
-        "conditionalStatement":"Required if Photometric Interpretation (0028,0004) is MONOCHROME2."
+        "conditionalStatement":"Required if Photometric Interpretation (0028,0004) is MONOCHROME2.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"frame-voi-lut",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"real-world-value-mapping",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"contrast-bolus-usage",
         "usage":"C",
-        "conditionalStatement":"Required if Contrast/Bolus Agent Sequence (0018,0012) is used."
+        "conditionalStatement":"Required if Contrast/Bolus Agent Sequence (0018,0012) is used.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"respiratory-synchronization",
         "usage":"C",
-        "conditionalStatement":"Required if Respiratory Motion Compensation Technique (0018,9170) equals other than NONE, REALTIME or BREATH_HOLD and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Respiratory Motion Compensation Technique (0018,9170) equals other than NONE, REALTIME or BREATH_HOLD and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-image-frame-type",
         "usage":"M",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-timing-and-related-parameters",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-fov-geometry",
         "usage":"C",
-        "conditionalStatement":"Required if Geometry of k-Space Traversal (0018,9032) equals RECTILINEAR and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Geometry of k-Space Traversal (0018,9032) equals RECTILINEAR and if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-echo",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-modifier",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-imaging-modifier",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-receive-coil",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-transmit-coil",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-diffusion",
         "usage":"C",
-        "conditionalStatement":"Required if Acquisition Contrast (0008,9209) in any MR Image Frame Type Functional Group in the SOP Instance equals DIFFUSION and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Acquisition Contrast (0008,9209) in any MR Image Frame Type Functional Group in the SOP Instance equals DIFFUSION and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-averages",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-spatial-saturation",
         "usage":"C",
-        "conditionalStatement":"Required if Spatial Pre-saturation (0018,9027) equals SLAB for any frame in the SOP Instance and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Spatial Pre-saturation (0018,9027) equals SLAB for any frame in the SOP Instance and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-metabolite-map",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 3 equals METABOLITE_MAP. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 3 equals METABOLITE_MAP. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-velocity-encoding",
         "usage":"C",
-        "conditionalStatement":"Required if Phase Contrast (0018,9014) equals YES and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise."
+        "conditionalStatement":"Required if Phase Contrast (0018,9014) equals YES and Image Type (0008,0008) Value 1 is ORIGINAL or MIXED. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"mr-arterial-spin-labeling",
         "usage":"C",
-        "conditionalStatement":"Required if Image Type (0008,0008) Value 3 is ASL. May be present otherwise."
+        "conditionalStatement":"Required if Image Type (0008,0008) Value 3 is ASL. May be present otherwise.",
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"functional-mr",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     },
     {
         "ciodId":"enhanced-mr-color-image",
         "macroId":"temporal-position",
         "usage":"U",
-        "conditionalStatement":null
+        "conditionalStatement":null,
+        "moduleType":"Multi-frame"
     }
 ]

--- a/standard/ciod_to_modules.json
+++ b/standard/ciod_to_modules.json
@@ -5629,7 +5629,7 @@
     },
     {
         "ciodId":"real-time-video-endoscopic-image",
-        "moduleId":"current-frame-functional-groups",
+        "moduleId":"real-time-video-endoscopic-image-current-frame-functional-groups",
         "usage":"M",
         "conditionalStatement":null,
         "informationEntity":"Image"
@@ -5790,7 +5790,7 @@
     },
     {
         "ciodId":"real-time-video-photographic-image",
-        "moduleId":"current-frame-functional-groups",
+        "moduleId":"real-time-video-photographic-image-current-frame-functional-groups",
         "usage":"M",
         "conditionalStatement":null,
         "informationEntity":"Image"
@@ -7918,7 +7918,7 @@
     },
     {
         "ciodId":"real-time-audio-waveform",
-        "moduleId":"current-frame-functional-groups",
+        "moduleId":"real-time-audio-waveform-current-frame-functional-groups",
         "usage":"M",
         "conditionalStatement":null,
         "informationEntity":"Waveform"

--- a/standard/modules.json
+++ b/standard/modules.json
@@ -1464,10 +1464,10 @@
         "linkToStandard":"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.28.html#table_C.7.6.28-1"
     },
     {
-        "name":"Multi-frame Functional Groups",
-        "id":"real-time-audio-waveform-multi-frame-functional-groups",
-        "description":"<p>\n<span href=\"#table_C.7.6.16-1\">This module </span> specifies the Attributes of the <a href=\"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.16.html#sect_C.7.6.16\" target=\"_blank\">Multi-frame Functional Groups Module</a>. This Module is included in SOP Instances even if there is only one frame in the Instance.</p>",
-        "linkToStandard":"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.16.html#table_C.7.6.16-1"
+        "name":"Current Frame Functional Groups",
+        "id":"real-time-audio-waveform-current-frame-functional-groups",
+        "description":"<p>\n<span href=\"#table_C.7.6.27-1\">This module </span> defines the Attributes related to the current frame when the IOD is transported using Real-Time Communication. It corresponds to the \"per-frame\" Attribute for the non-Real-Time IODs.</p>",
+        "linkToStandard":"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.27.html#table_C.7.6.27-1"
     },
     {
         "name":"Real-Time Bulk Data Flow",
@@ -1476,16 +1476,16 @@
         "linkToStandard":"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.26.html#table_C.7.6.26-1"
     },
     {
-        "name":"Multi-frame Functional Groups",
-        "id":"real-time-video-endoscopic-image-multi-frame-functional-groups",
-        "description":"<p>\n<span href=\"#table_C.7.6.16-1\">This module </span> specifies the Attributes of the <a href=\"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.16.html#sect_C.7.6.16\" target=\"_blank\">Multi-frame Functional Groups Module</a>. This Module is included in SOP Instances even if there is only one frame in the Instance.</p>",
-        "linkToStandard":"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.16.html#table_C.7.6.16-1"
+        "name":"Current Frame Functional Groups",
+        "id":"real-time-video-endoscopic-image-current-frame-functional-groups",
+        "description":"<p>\n<span href=\"#table_C.7.6.27-1\">This module </span> defines the Attributes related to the current frame when the IOD is transported using Real-Time Communication. It corresponds to the \"per-frame\" Attribute for the non-Real-Time IODs.</p>",
+        "linkToStandard":"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.27.html#table_C.7.6.27-1"
     },
     {
-        "name":"Multi-frame Functional Groups",
-        "id":"real-time-video-photographic-image-multi-frame-functional-groups",
-        "description":"<p>\n<span href=\"#table_C.7.6.16-1\">This module </span> specifies the Attributes of the <a href=\"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.16.html#sect_C.7.6.16\" target=\"_blank\">Multi-frame Functional Groups Module</a>. This Module is included in SOP Instances even if there is only one frame in the Instance.</p>",
-        "linkToStandard":"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.16.html#table_C.7.6.16-1"
+        "name":"Current Frame Functional Groups",
+        "id":"real-time-video-photographic-image-current-frame-functional-groups",
+        "description":"<p>\n<span href=\"#table_C.7.6.27-1\">This module </span> defines the Attributes related to the current frame when the IOD is transported using Real-Time Communication. It corresponds to the \"per-frame\" Attribute for the non-Real-Time IODs.</p>",
+        "linkToStandard":"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.27.html#table_C.7.6.27-1"
     },
     {
         "name":"Real World Value Mapping",

--- a/tests/end_to_end_test.py
+++ b/tests/end_to_end_test.py
@@ -186,7 +186,8 @@ def test_trace_from_ciod_to_func_group_attribute(ciod_fg_macro_relationship, cio
         "ciodId": "enhanced-mr-image",
         "macroId": "referenced-image",
         "usage": "C",
-        "conditionalStatement": "Required if the image or frame has been planned on another image or frame. May be present otherwise"
+        "conditionalStatement": "Required if the image or frame has been planned on another image or frame. May be present otherwise",
+        "moduleType": "Multi-frame"
     }
     macro_attr = {
         "macroId": "referenced-image",

--- a/tests/postprocess_integrate_func_group_macros_test.py
+++ b/tests/postprocess_integrate_func_group_macros_test.py
@@ -1,42 +1,49 @@
-from dicom_standard.postprocess_integrate_func_group_macros import update_description, process_macro_attributes, process_mffg_attributes
+from dicom_standard.postprocess_integrate_func_group_macros import (
+    update_description,
+    process_mffg_macro_attributes,
+    process_cffg_macro_attributes,
+    process_fg_attributes,
+)
+from dicom_standard.process_modules import MF_FUNC_GROUP_MODULE_ID, CF_FUNC_GROUP_MODULE_ID
+
+example_macro_attrs = [
+    {
+        'macroId': 'example-macro-1',
+        'path': 'example-macro-1:0001',
+        'description': 'Attribute of Example Macro 1.'
+    },
+    {
+        'macroId': 'example-macro-1',
+        'path': 'example-macro-1:0001:0002',
+        'description': 'Sub-attribute of Example Macro 1.'
+    },
+]
+example_macro = {
+    'macroName': 'Example Macro 1',
+    'ciodId': 'example-ciod',
+    'macroId': 'example-macro-1',
+    'usage': 'C',
+    'conditionalStatement': 'Required if Test Macro present.',
+}
 
 
 def test_update_description_adds_period_to_conditional():
     example_attr = {
         'macroId': 'example-macro-1',
         'path': 'example-macro-1:0001',
-        'description': 'Attribute of example macro 1.'
+        'description': 'Attribute of Example Macro 1.'
     }
-    example_macro = {
-        'macroName': 'Example Macro',
+    example_macro_without_period = {
+        'macroName': 'Example Macro 1',
         'usage': 'C',
         'conditionalStatement': 'Conditional without period',
     }
     expected_updated_conditonal = 'Conditional without period.'
-    update_description(example_attr, example_macro)
+    update_description(example_attr, example_macro_without_period)
     assert expected_updated_conditonal in example_attr['description']
 
 
-def test_process_macro_attributes():
-    example_macro_attrs = [
-        {
-            'macroId': 'example-macro-1',
-            'path': 'example-macro-1:0001',
-            'description': 'Attribute of Example Macro 1.'
-        },
-        {
-            'macroId': 'example-macro-1',
-            'path': 'example-macro-1:0001:0002',
-            'description': 'Sub-attribute of Example Macro 1.'
-        },
-    ]
-    example_macro = {
-        'macroName': 'Example Macro 1',
-        'ciodId': 'example-ciod',
-        'macroId': 'example-macro-1',
-        'usage': 'C',
-        'conditionalStatement': 'Required if Test Macro present.',
-    }
+def test_process_mffg_macro_attributes():
     expected_processed_attrs = [
         {
             'moduleId': 'example-ciod-multi-frame-functional-groups',
@@ -67,12 +74,32 @@ def test_process_macro_attributes():
                            '<p>Required if Test Macro present.</p>'
         },
     ]
-    assert process_macro_attributes(example_macro_attrs, example_macro) == expected_processed_attrs
+    assert process_mffg_macro_attributes(example_macro_attrs, example_macro) == expected_processed_attrs
 
 
-def test_process_mffg_attributes():
+def test_process_cffg_macro_attributes():
+    expected_processed_attrs = [
+        {
+            'moduleId': 'example-ciod-current-frame-functional-groups',
+            'path': 'example-ciod-current-frame-functional-groups:00060001:0001',
+            'description': 'Attribute of Example Macro 1.<h3>Note</h3>'
+                           '<p>Part of the Example Macro 1 Functional Group Macro with usage: C</p>'
+                           '<p>Required if Test Macro present.</p>'
+        },
+        {
+            'moduleId': 'example-ciod-current-frame-functional-groups',
+            'path': 'example-ciod-current-frame-functional-groups:00060001:0001:0002',
+            'description': 'Sub-attribute of Example Macro 1.<h3>Note</h3>'
+                           '<p>Part of the Example Macro 1 Functional Group Macro with usage: C</p>'
+                           '<p>Required if Test Macro present.</p>'
+        },
+    ]
+    assert process_cffg_macro_attributes(example_macro_attrs, example_macro) == expected_processed_attrs
+
+
+def test_process_fg_attributes():
     example_ciods = ['example-ciod-1', 'example-ciod-2']
-    example_mffg_attrs = [
+    example_module_to_attr = [
         {
             'moduleId': 'multi-frame-functional-groups',
             'path': 'multi-frame-functional-groups:0001',
@@ -81,8 +108,12 @@ def test_process_mffg_attributes():
             'moduleId': 'multi-frame-functional-groups',
             'path': 'multi-frame-functional-groups:0001:0002',
         },
+        {
+            'moduleId': 'current-frame-functional-groups',
+            'path': 'current-frame-functional-groups:1001',
+        },
     ]
-    expected_processed_attrs = [
+    expected_processed_mffg_attrs = [
         {
             'moduleId': 'example-ciod-1-multi-frame-functional-groups',
             'path': 'example-ciod-1-multi-frame-functional-groups:0001',
@@ -100,4 +131,15 @@ def test_process_mffg_attributes():
             'path': 'example-ciod-2-multi-frame-functional-groups:0001:0002',
         },
     ]
-    assert process_mffg_attributes(example_ciods, example_mffg_attrs) == expected_processed_attrs
+    expected_processed_cffg_attrs = [
+        {
+            'moduleId': 'example-ciod-1-current-frame-functional-groups',
+            'path': 'example-ciod-1-current-frame-functional-groups:1001',
+        },
+        {
+            'moduleId': 'example-ciod-2-current-frame-functional-groups',
+            'path': 'example-ciod-2-current-frame-functional-groups:1001',
+        },
+    ]
+    assert process_fg_attributes(example_module_to_attr, example_ciods, MF_FUNC_GROUP_MODULE_ID) == expected_processed_mffg_attrs
+    assert process_fg_attributes(example_module_to_attr, example_ciods, CF_FUNC_GROUP_MODULE_ID) == expected_processed_cffg_attrs


### PR DESCRIPTION
Similar to the "Multi-frame Functional Groups" module, the "Current Frame Functional Groups" module also uses functional group macros:
![image](https://user-images.githubusercontent.com/9055029/83215569-ec1a4900-a12c-11ea-9d40-9b06e526f762.png)

This PR contains updates to the processing modules to create the relevant attributes in a way similar to that used to handle the "Multi-frame Functional Groups" attributes.

DICOM browser with updated files:
![image](https://user-images.githubusercontent.com/9055029/83215889-8f6b5e00-a12d-11ea-979e-86505438691c.png)
