### PR TITLE
Capital

### DIFF
--- a/dicom_standard/process_ciod_module_relationship.py
+++ b/dicom_standard/process_ciod_module_relationship.py
@@ -43,6 +43,10 @@ def define_ciod_module_relationship(ciod, module):
         information_entity = 'Image'
     ciod_id = pl.create_slug(ciod)
     module_id = pl.create_slug(pl.text_from_html_string(module['module']))
+    # Standard workaround: Fix inconsistent capitalization in the "Information Entity" field of Rendition Selection Document
+    # http://dicom.nema.org/medical/dicom/2019e/output/chtml/part03/sect_A.35.21.3.html#table_A.35.21-1
+    if ciod == 'Rendition Selection Document' and module_id == 'synchronization':
+        information_entity = 'Frame of Reference'
     # Create CIOD-specific "Multi-frame Functional Group" module IDs
     if module_id == MF_FUNC_GROUP_MODULE_ID:
         module_id = f'{ciod_id}-{module_id}'

--- a/tests/standard_workarounds_test.py
+++ b/tests/standard_workarounds_test.py
@@ -60,6 +60,13 @@ def test_missing_ie_field_in_table_a_32_10_1(part03):
     assert empty_ie_rows, 'Table no longer contains rows with an empty "Information Entity" field'
 
 
+def test_upper_case_O_in_table_a_35_21_1(part03):
+    rows = get_table_rows_from_ids(part03, ['table_A.35.21-1'], col_titles=['information_entity'])
+    information_entity = 'Frame'
+    row = next(filter(lambda r: information_entity in r['information_entity'], rows))
+    assert 'Of' in row['information_entity'], 'Table no longer contains capital "O"'
+
+
 def test_sect_tid_1004_invalid_url():
     test_url = 'http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_TID_1004.html#sect_TID_1004'
     status_code = requests.get(test_url).status_code


### PR DESCRIPTION
Fixed capitalization error in rendition selection document. (#45)

- Created check for upper-case "O" for the Frame of Reference IE in process_ciod_module_relationship.py
- Created standard workaround to check for this inconsistency

TODO:

- Add row to DICOM Standard Workarounds table in README:

Issue description                                                                                            |    Workaround Location
Table A.35.21-1 contains an upper-case "O" in the Frame of Reference IE   |   process_ciod_module_relationship.py

