### PR TITLE
Update travis build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ python:
     - "3.7"
 before_install:
 - deactivate
+- pyenv global 3.7.1
+- python3.7 -m pip install -U tox --user
 install:
- - pyenv install -v 3.7.1
- - pyenv global 3.7.1
- - python3.7 -m pip install -U tox --user
  - python3.7 -m tox --notest
 script: python3.7 -m tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 - pyenv global 3.7.1
 - python3.7 -m pip install -U tox --user
 install:
- - python3.7 -m tox --notest
+- python3.7 -m tox --notest
 script: python3.7 -m tox
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-    - "3.7"
+    - "3.7.1"
 before_install:
 - deactivate
 - python3.7 -m pip install -U tox --user

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ python:
     - "3.7"
 before_install:
 - deactivate
-- pyenv global 3.7
 - python3.7 -m pip install -U tox --user
 install:
 - python3.7 -m tox --notest
+- pyenv install -v 3.7.1
+before_script:
+- pyenv global 3.7.1
 script: python3.7 -m tox
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 sudo: false
 language: python
 python:
-    - "3.7.1"
+    - "3.7"
 before_install:
 - deactivate
-- python3.7 -m pip install -U tox --user
 install:
-- python3.7 -m tox --notest
-- pyenv install -v 3.7.1
-before_script:
-- pyenv global 3.7.1
+ - pyenv install -v 3.7.1
+ - pyenv global 3.7.1
+ - python3.7 -m pip install -U tox --user
+ - python3.7 -m tox --notest
 script: python3.7 -m tox
 notifications:
   email: false


### PR DESCRIPTION
Specified python version being used by travis. (#53)

- Used 3.7.1 instead of 3.7 in the "before_install" section of the travis.yml file
- Change was necessary because of updated python support: 
https://github.com/travis-ci/docs-travis-ci-com/commit/fb874199d60aa8b90f6aae80e165187b9fa6a38c