### PR TITLE
2023b update: add workaround for mismatches in retirement between table 6-1 and E.1-1

### DIFF
--- a/dicom_standard/extract_conf_profile_attributes.py
+++ b/dicom_standard/extract_conf_profile_attributes.py
@@ -18,6 +18,10 @@ TABLE_ID = 'table_E.1-1'
 
 AttrTableType = List[Dict[str, Union[str, bool]]]
 
+def ignore_retirement_mismatch(attr_name: str) -> bool:
+    if attr_name in [ 'Time of Document or Verbal Transaction (Trial)']:
+        return True
+    return False
 
 def get_conf_profile_table(standard: BeautifulSoup) -> List[TableDictType]:
     all_tables = standard.find_all('div', class_='table')
@@ -41,10 +45,10 @@ def verify_table_integrity(parsed_table_data: List[TableDictType], attributes: A
     for attr in parsed_table_data:
         attr_name = attr['name']
         retired = attr['retired'] == 'Y'
-        if retired and attr['name'] not in retired_attrs:
+        if retired and attr['name'] not in retired_attrs and not ignore_retirement_mismatch(attr_name):
             errors.append(f'Attribute "{attr_name}" {attr["tag"]} is retired in Table '
                           'E.1-1 but not in Table 6-1.')
-        if not retired and attr['name'] in retired_attrs:
+        if not retired and attr['name'] in retired_attrs and not ignore_retirement_mismatch(attr_name):
             errors.append(f'Attribute "{attr_name}" {attr["tag"]} is retired in Table '
                           '6-1 but not in Table E.1-1.')
     if errors:

--- a/dicom_standard/extract_conf_profile_attributes.py
+++ b/dicom_standard/extract_conf_profile_attributes.py
@@ -18,10 +18,21 @@ TABLE_ID = 'table_E.1-1'
 
 AttrTableType = List[Dict[str, Union[str, bool]]]
 
+
 def ignore_retirement_mismatch(attr_name: str) -> bool:
-    if attr_name in [ 'Time of Document or Verbal Transaction (Trial)']:
+    """Standard workaround: Indicates that an attribute name should be ignored if there is a retirement mismatch
+    The list of specific known mismatches to be worked around is hardcoded internally
+
+    Args:
+        attr_name (str): _description_
+
+    Returns:
+        bool: _description_
+    """
+    if attr_name in ['Time of Document or Verbal Transaction (Trial)']:
         return True
     return False
+
 
 def get_conf_profile_table(standard: BeautifulSoup) -> List[TableDictType]:
     all_tables = standard.find_all('div', class_='table')


### PR DESCRIPTION
  The workaround contains a hard-coded list of attribute names that need to be worked around
added specific attribute name that was mismatched in 2023b to list:
`Time of Document or Verbal Transaction (Trial)`