### PR TITLE
fix: fixes wrong action for Tag (0008,1120) - Referenced Patient Sequ…

### DIFF
--- a/standard/confidentiality_profile_attributes.json
+++ b/standard/confidentiality_profile_attributes.json
@@ -2407,7 +2407,7 @@
         "tag":"(0008,1120)",
         "stdCompIOD":"Y",
         "basicProfile":"X",
-        "rtnUIDsOpt":"X",
+        "rtnUIDsOpt":"K",
         "id":"00081120"
     },
     {


### PR DESCRIPTION
Bug description
Wrong entry in [confidentiality_profile_attributes.json](https://github.com/innolitics/dicom-standard/blob/master/standard/confidentiality_profile_attributes.json):

Tag (0008,1120) - Referenced Patient Sequence:
reads: "rtnUIDsOpt":"X", but the [Attribute Confidentiality Profiles](https://dicom.nema.org/medical/dicom/current/output/chtml/part15/chapter_E.html) states K for that tag.

Expected behavior
Change X (Remove) to K (Keep)