### PR TITLE
More updates for 2024e

### DIFF
--- a/.github/workflows/update-standard.yml
+++ b/.github/workflows/update-standard.yml
@@ -66,8 +66,9 @@ jobs:
         if: steps.diff_files.outputs.diff_lines > 0
       - name: Run tests
         run: tox
-      - name: Publish to master
-        uses: mikeal/publish-to-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: success() && steps.diff_files.outputs.diff_lines > 0
+      # temporary disable "publish to master", which may commit the changes in an unapproved PR  
+      # - name: Publish to master
+      #   uses: mikeal/publish-to-github-action@master
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   if: success() && steps.diff_files.outputs.diff_lines > 0

--- a/.github/workflows/update-standard.yml
+++ b/.github/workflows/update-standard.yml
@@ -57,7 +57,7 @@ jobs:
           name: new_standard
           path: new_standard/
       - name: Diff JSON files
-        run: echo ::set-output name=diff_lines::$(diff -qr standard new_standard | grep -v ".gitignore" | wc -l)
+        run: echo "diff_lines=$(diff -qr standard new_standard | grep -v '.gitignore' | wc -l)" >> $GITHUB_OUTPUT
         id: diff_files
       - name: Update standard
         run: |

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Certain parts of the DICOM Standard site cause errors when running the parser, o
 
 When we find one of these issues, we add a hard-coded fix in the relevant file and add a comment starting with 'Standard workaround' that describes the issue and links to its location in the Standard. To be aware when these fixes are obsolete, we add a unit test that fails once the issue no longer exists.
 
-Current standard workarounds (as of rev.2024b):
+Current standard workarounds (as of rev.2024e):
 | *Issue description* | *Workaround location* |
 |---|---|
 | [Table TID 1004](http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_1004) has a section URL pattern ("sect_TID_1004") that doesn't exist within the HTML version of the standard | `parse_lib.py` |
@@ -253,13 +253,14 @@ Current standard workarounds (as of rev.2024b):
 | The [Confocal Microscopy Image Functional Group Macros](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.90.html#sect_A.90.1.5) section doesn't have a description, causing the "module_type" value to be None when it should be "Multi-frame" | `extract_ciod_func_group_macro_tables.py` |
 | The [Confocal Microscopy Tiled Pyramidal Image Functional Group Macros](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.90.2.5.html#sect_A.90.2.5) section doesn't have a description, causing the "module_type" value to be None when it should be "Multi-frame" | `extract_ciod_func_group_macro_tables.py` |
 | [Table A.89.4-1](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.89.4.html#table_A.89.4-1) is missing part of the IOD name ("Photoacoustic" instead of "Photoacoustic Image") in its title | `extract_ciod_func_group_macro_tables.py` |
-| The "Confocal Micrsocopy Tiled Pyramidal" IOD Specification in [Table B.5-1](https://dicom.nema.org/medical/dicom/current/output/chtml/part04/sect_B.5.html#table_B.5-1) should include the word "Image" after "Pyramidal" | `extract_sops.py`
-| The "Pseudo-color Softcopy Presentation State" IOD Specification in [Table B.5-1](https://dicom.nema.org/medical/dicom/current/output/chtml/part04/sect_B.5.html#table_B.5-1) should have an upper-case "C" in "Color" | `extract_sops.py`
+| The "Confocal Micrsocopy Tiled Pyramidal" IOD Specification in [Table B.5-1](https://dicom.nema.org/medical/dicom/current/output/chtml/part04/sect_B.5.html#table_B.5-1) should include the word "Image" after "Pyramidal" | `extract_sops.py` |
+| The "Pseudo-color Softcopy Presentation State" IOD Specification in [Table B.5-1](https://dicom.nema.org/medical/dicom/current/output/chtml/part04/sect_B.5.html#table_B.5-1) should have an upper-case "C" in "Color" | `extract_sops.py` |
+| \*The "Enhanced MR Image" attribute appears twice in [Table C.8-79](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.8.13.html#table_C.8-79) with the same hierarchy without a conditional statement | `postprocess_merge_duplicate_nodes.py` |
 
 (\*) This issue is not caused by a typo or error in the Standard but rather an exception from the normal format and thus does not have a unit test for a fix.
 
 Fixed workarounds:
-| *Issue description* | *Workaround location* | *Fixed as of*
+| *Issue description* | *Workaround location* | *Fixed as of* |
 |---|---|---|
 | [Table A.39.19-1](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.35.19.3.html) ends its title with an upper case "S" | `extract_ciod_module_tables.py`<br>`parse_lib.py` | 2023e |
 | [Table A.32.9-2](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.32.9.3.4.html#table_A.32.9-2) has "Functional Groups Macros" in its title while other tables use "Functional Group Macros" | `extract_ciod_func_group_macro_tables.py`<br>`parse_lib.py` | 2023e |
@@ -271,7 +272,7 @@ Fixed workarounds:
 | [Table A.35.21-1](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.35.21.3.html#table_A.35.21-1) contains an upper case "O" in "Frame of Reference", while other tables use the lower case | `process_ciod_module_relationship.py` | 2023e |
 | [The File-Set Identification Module](http://dicom.nema.org/dicom/2013/output/chtml/part03/sect_F.3.html#sect_F.3.2.1) has no description paragraph | `extract_modules_macros_with_attributes.py` | 2023e |
 | [Table C.8.34.5.1-1](https://dicom.nema.org/medical/dicom/2023c/output/chtml/part03/sect_C.8.34.5.html#table_C.8.34.5.1-1) Macro table 'Photoacoustic Excitation Characteristics Attributes' is not using suffix 'Macro Attributes' | `extract_modules_macros_with_attributes.py`<br>`parse_lib.py` | 2023e |
-| \*The "Enhanced MR Image" attribute appears twice in [Table C.8-79](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.8.13.html#table_C.8-79) with the same hierarchy without a conditional statement | `postprocess_merge_duplicate_nodes.py` | 2024e |
+| \*The "Content Creator's Name" attribute appears twice in [Table C.36.8-1](http://dicom.nema.org/medical/dicom/2019c/output/chtml/part03/sect_C.36.8.html#table_C.36.8-1) with the same hierarchy without a conditional statement | `postprocess_merge_duplicate_nodes.py` | 2023e |
 | \*[Table F.3-3](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_F.3.2.2.html#table_F.3-3) contains a "Record Selection Keys" attribute with an invalid tag ("See F.5") | `preprocess_modules_with_attributes.py` | 2023e |
 
 ## Contact

--- a/tests/end_to_end_test.py
+++ b/tests/end_to_end_test.py
@@ -133,10 +133,10 @@ def test_valid_ciod_names(sops, ciods):
 @pytest.mark.endtoend
 def test_vertical_samples_from_standard(ciods, modules, attributes):
     test_ciod = {
-        "name": "Ultrasound Multi-frame Image",
-        "id": "ultrasound-multi-frame-image",
-        "description": "<p>\nThe Ultrasound Multi-frame Image IOD specifies a Multi-frame image that has been created by an ultrasound imaging device.</p>",
-        "linkToStandard": "http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.7.4.html#table_A.7-1"
+        "name":"Ultrasound Multi-frame Image",
+        "id":"ultrasound-multi-frame-image",
+        "description":"<p>\nThe <a href=\"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.7.html#sect_A.7\" target=\"_blank\">Ultrasound Multi-frame Image IOD</a> specifies a Multi-frame Image that has been created by an ultrasound imaging device.</p>",
+        "linkToStandard":"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.7.4.html#table_A.7-1"
     }
     test_module = {
         "name": "Patient",
@@ -282,10 +282,10 @@ def test_trace_from_attribute_to_ciod(ciods, ciod_module_relationship, modules,
         "informationEntity": "Study"
     }
     ciod = {
-        "name": "Computed Radiography Image",
-        "id": "computed-radiography-image",
-        "description": "<p>\nThe Computed Radiography (CR) Image IOD specifies an image that has been created by a computed radiography imaging device.</p>",
-        "linkToStandard": "http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.2.3.html#table_A.2-1"
+        "name":"Computed Radiography Image",
+        "id":"computed-radiography-image",
+        "description":"<p>\nThe <a href=\"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.2.html#sect_A.2\" target=\"_blank\">Computed Radiography Image IOD</a> specifies an image that has been created by a computed radiography imaging device.</p>",
+        "linkToStandard":"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.2.3.html#table_A.2-1"
     }
     assert attr in attributes
     assert module_attr[0] in module_attribute_relationship

--- a/tests/end_to_end_test.py
+++ b/tests/end_to_end_test.py
@@ -133,10 +133,10 @@ def test_valid_ciod_names(sops, ciods):
 @pytest.mark.endtoend
 def test_vertical_samples_from_standard(ciods, modules, attributes):
     test_ciod = {
-        "name":"Ultrasound Multi-frame Image",
-        "id":"ultrasound-multi-frame-image",
-        "description":"<p>\nThe <a href=\"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.7.html#sect_A.7\" target=\"_blank\">Ultrasound Multi-frame Image IOD</a> specifies a Multi-frame Image that has been created by an ultrasound imaging device.</p>",
-        "linkToStandard":"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.7.4.html#table_A.7-1"
+        "name": "Ultrasound Multi-frame Image",
+        "id": "ultrasound-multi-frame-image",
+        "description": "<p>\nThe <a href=\"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.7.html#sect_A.7\" target=\"_blank\">Ultrasound Multi-frame Image IOD</a> specifies a Multi-frame Image that has been created by an ultrasound imaging device.</p>",
+        "linkToStandard": "http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.7.4.html#table_A.7-1"
     }
     test_module = {
         "name": "Patient",
@@ -282,10 +282,10 @@ def test_trace_from_attribute_to_ciod(ciods, ciod_module_relationship, modules,
         "informationEntity": "Study"
     }
     ciod = {
-        "name":"Computed Radiography Image",
-        "id":"computed-radiography-image",
-        "description":"<p>\nThe <a href=\"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.2.html#sect_A.2\" target=\"_blank\">Computed Radiography Image IOD</a> specifies an image that has been created by a computed radiography imaging device.</p>",
-        "linkToStandard":"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.2.3.html#table_A.2-1"
+        "name": "Computed Radiography Image",
+        "id": "computed-radiography-image",
+        "description": "<p>\nThe <a href=\"http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.2.html#sect_A.2\" target=\"_blank\">Computed Radiography Image IOD</a> specifies an image that has been created by a computed radiography imaging device.</p>",
+        "linkToStandard": "http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.2.3.html#table_A.2-1"
     }
     assert attr in attributes
     assert module_attr[0] in module_attribute_relationship

--- a/tests/standard_workarounds_test.py
+++ b/tests/standard_workarounds_test.py
@@ -94,6 +94,11 @@ def get_table_title_from_id(standard, table_id):
 #     assert 'Macro Attributes' not in table_title, 'Table title now contains suffix "Macro Attributes"'
 
 
+# def test_missing_word_in_table_a_89_4_1_title(part03):
+#     table_title = get_table_title_from_id(part03, 'table_A.89.4-1')
+#     assert 'Photoacoustic Image' not in table_title, 'Table title now contains full macro name ("Photoacoustic Image Functional Group Macros")'
+
+
 def test_sect_tid_1004_invalid_url():
     test_url = 'http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_TID_1004.html#sect_TID_1004'
     status_code = requests.get(test_url).status_code
@@ -143,12 +148,6 @@ def test_missing_module_type_in_section_a_90_2_5_description(part03):
 #     #for attr in RETIREMENT_MISMATCH_ATTRIBUTES:
 #     #    assert table_description_text == table_title, f'{attr} no longer has a retirement value mismatch in tables 6-1 and E.1-1'
 #     assert False
-
-
-def test_missing_word_in_table_a_89_4_1_title(part03):
-    table_title = get_table_title_from_id(part03, 'table_A.89.4-1')
-    assert 'Photoacoustic Image' not in table_title, 'Table title now contains full macro name ("Photoacoustic Image Functional Group Macros")'
-
 
 def test_missing_word_in_table_b_5_1(part04):
     table = get_table_rows_from_ids(part04, ['table_B.5-1'], ['name', 'id', 'ciod'])


### PR DESCRIPTION
- Amend the readme.md
  - Correct the workaround list
- Update the test cases
  - Remove the obsolete workaround
- update e2e test case
- flake8
- retire `::set-output`
- disable workflow step "publish to master"