### PR TITLE
update workaround test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,6 @@ Current standard workarounds (as of rev.2024e):
 | The [Confocal Microscopy Image Functional Group Macros](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.90.html#sect_A.90.1.5) section doesn't have a description, causing the "module_type" value to be None when it should be "Multi-frame" | `extract_ciod_func_group_macro_tables.py` |
 | The [Confocal Microscopy Tiled Pyramidal Image Functional Group Macros](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.90.2.5.html#sect_A.90.2.5) section doesn't have a description, causing the "module_type" value to be None when it should be "Multi-frame" | `extract_ciod_func_group_macro_tables.py` |
 | [Table A.89.4-1](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.89.4.html#table_A.89.4-1) is missing part of the IOD name ("Photoacoustic" instead of "Photoacoustic Image") in its title | `extract_ciod_func_group_macro_tables.py` |
-| The "Confocal Micrsocopy Tiled Pyramidal" IOD Specification in [Table B.5-1](https://dicom.nema.org/medical/dicom/current/output/chtml/part04/sect_B.5.html#table_B.5-1) should include the word "Image" after "Pyramidal" | `extract_sops.py` |
 | The "Pseudo-color Softcopy Presentation State" IOD Specification in [Table B.5-1](https://dicom.nema.org/medical/dicom/current/output/chtml/part04/sect_B.5.html#table_B.5-1) should have an upper-case "C" in "Color" | `extract_sops.py` |
 | \*The "Enhanced MR Image" attribute appears twice in [Table C.8-79](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.8.13.html#table_C.8-79) with the same hierarchy without a conditional statement | `postprocess_merge_duplicate_nodes.py` |
 
@@ -274,6 +273,7 @@ Fixed workarounds:
 | [Table C.8.34.5.1-1](https://dicom.nema.org/medical/dicom/2023c/output/chtml/part03/sect_C.8.34.5.html#table_C.8.34.5.1-1) Macro table 'Photoacoustic Excitation Characteristics Attributes' is not using suffix 'Macro Attributes' | `extract_modules_macros_with_attributes.py`<br>`parse_lib.py` | 2023e |
 | \*The "Content Creator's Name" attribute appears twice in [Table C.36.8-1](http://dicom.nema.org/medical/dicom/2019c/output/chtml/part03/sect_C.36.8.html#table_C.36.8-1) with the same hierarchy without a conditional statement | `postprocess_merge_duplicate_nodes.py` | 2023e |
 | \*[Table F.3-3](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_F.3.2.2.html#table_F.3-3) contains a "Record Selection Keys" attribute with an invalid tag ("See F.5") | `preprocess_modules_with_attributes.py` | 2023e |
+| The "Confocal Micrsocopy Tiled Pyramidal" IOD Specification in [Table B.5-1](https://dicom.nema.org/medical/dicom/current/output/chtml/part04/sect_B.5.html#table_B.5-1) should include the word "Image" after "Pyramidal" | `extract_sops.py` | 2024e |
 
 ## Contact
 

--- a/dicom_standard/extract_sops.py
+++ b/dicom_standard/extract_sops.py
@@ -10,10 +10,6 @@ TABLE_IDS = ['table_B.5-1', 'table_I.4-1', 'table_GG.3-1']
 
 def generate_ciod_id(name: str) -> str:
     cleaned_name = name.split('IOD')[0].strip()
-    # Standard workaround: Table B.5-1 is missing part of the IOD name ("Confocal Microscopy Tiled Pyramidal" instead of "Confocal Microscopy Tiled Pyramidal Image")
-    # https://dicom.nema.org/medical/dicom/current/output/chtml/part04/sect_B.5.html#table_B.5-1
-    if cleaned_name == 'Confocal Microscopy Tiled Pyramidal':
-        cleaned_name = 'Confocal Microscopy Tiled Pyramidal Image'
     # Standard workaround: Table B.5-1 has a miscapitalized word in an IOD Specification
     # https://dicom.nema.org/medical/dicom/current/output/chtml/part04/sect_B.5.html#table_B.5-1
     if cleaned_name == 'Pseudo-color Softcopy Presentation State':

--- a/tests/standard_workarounds_test.py
+++ b/tests/standard_workarounds_test.py
@@ -151,11 +151,11 @@ def test_missing_module_type_in_section_a_90_2_5_description(part03):
 
 def test_missing_word_in_table_b_5_1(part04):
     table = get_table_rows_from_ids(part04, ['table_B.5-1'], ['name', 'id', 'ciod'])
-    row = next(row for row in table if 'Confocal Microscopy' in row['ciod'])
-    assert row['ciod'] != 'Confocal Microscopy Tiled Pyramidal Image', 'Row now contains full IOD name'
+    row = next(row for row in table if 'Confocal Microscopy Tiled' in row['ciod'])
+    assert row['ciod'] != 'Confocal Microscopy Tiled Pyramidal Image IOD', 'Row now contains full IOD name'
 
 
 def test_miscapitalized_word_in_table_b_5_1(part04):
     table = get_table_rows_from_ids(part04, ['table_B.5-1'], ['name', 'id', 'ciod'])
-    row = next(row for row in table if 'Softcopy Presentation State' in row['ciod'])
-    assert row['ciod'] != 'Pseudo-Color Softcopy Presentation State', 'Row now contains correct capitalization'
+    row = next(row for row in table if 'Pseudo-color Softcopy Presentation State'.lower() in row['ciod'].lower())
+    assert row['ciod'] != 'Pseudo-Color Softcopy Presentation State IOD', 'Row now contains correct capitalization'

--- a/tests/standard_workarounds_test.py
+++ b/tests/standard_workarounds_test.py
@@ -99,6 +99,12 @@ def get_table_title_from_id(standard, table_id):
 #     assert 'Photoacoustic Image' not in table_title, 'Table title now contains full macro name ("Photoacoustic Image Functional Group Macros")'
 
 
+# def test_missing_word_in_table_b_5_1(part04):
+#     table = get_table_rows_from_ids(part04, ['table_B.5-1'], ['name', 'id', 'ciod'])
+#     row = next(row for row in table if 'Confocal Microscopy Tiled' in row['ciod'])
+#     assert row['ciod'] != 'Confocal Microscopy Tiled Pyramidal Image IOD', 'Row now contains full IOD name'
+
+
 def test_sect_tid_1004_invalid_url():
     test_url = 'http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_TID_1004.html#sect_TID_1004'
     status_code = requests.get(test_url).status_code
@@ -148,11 +154,6 @@ def test_missing_module_type_in_section_a_90_2_5_description(part03):
 #     #for attr in RETIREMENT_MISMATCH_ATTRIBUTES:
 #     #    assert table_description_text == table_title, f'{attr} no longer has a retirement value mismatch in tables 6-1 and E.1-1'
 #     assert False
-
-def test_missing_word_in_table_b_5_1(part04):
-    table = get_table_rows_from_ids(part04, ['table_B.5-1'], ['name', 'id', 'ciod'])
-    row = next(row for row in table if 'Confocal Microscopy Tiled' in row['ciod'])
-    assert row['ciod'] != 'Confocal Microscopy Tiled Pyramidal Image IOD', 'Row now contains full IOD name'
 
 
 def test_miscapitalized_word_in_table_b_5_1(part04):


### PR DESCRIPTION
- Fix the IOD workaround test cases
- `test_missing_word_in_table_b_5_1` is not needed in 2024e