### PR TITLE
Fix update-standard workflow

### DIFF
--- a/.github/workflows/update-standard.yml
+++ b/.github/workflows/update-standard.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: new_standard
-          path: dicom_standard/dist
+          path: dicom_standard/dist/*
   test-and-commit:
     needs: make
     name: Run tox and commit to master

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Completely processed:
 
 Processed for references:
 
+- PS3.10
 - PS3.15
 - PS3.16
 - PS3.17

--- a/dicom_standard/Makefile
+++ b/dicom_standard/Makefile
@@ -112,6 +112,7 @@ updatestandard:
 	wget --compression=auto http://dicom.nema.org/medical/dicom/${VERSION}/output/html/part03.html -O standard/part03.html
 	wget --compression=auto http://dicom.nema.org/medical/dicom/${VERSION}/output/html/part04.html -O standard/part04.html
 	wget --compression=auto http://dicom.nema.org/medical/dicom/${VERSION}/output/html/part06.html -O standard/part06.html
+	wget --compression=auto http://dicom.nema.org/medical/dicom/${VERSION}/output/html/part10.html -O standard/part10.html
 	wget --compression=auto http://dicom.nema.org/medical/dicom/${VERSION}/output/html/part15.html -O standard/part15.html
 	wget --compression=auto http://dicom.nema.org/medical/dicom/${VERSION}/output/html/part16.html -O standard/part16.html
 	wget --compression=auto http://dicom.nema.org/medical/dicom/${VERSION}/output/html/part17.html -O standard/part17.html

--- a/dicom_standard/process_ciod_module_relationship.py
+++ b/dicom_standard/process_ciod_module_relationship.py
@@ -3,6 +3,7 @@ Takes the extracted CIOD-Module table information to build a list of all
 CIOD-Module relationships defined in the DICOM Standard.
 '''
 import sys
+import re
 
 from dicom_standard import parse_lib as pl
 from dicom_standard.process_modules import MF_FUNC_GROUP_MODULE_ID, CF_FUNC_GROUP_MODULE_ID
@@ -74,6 +75,10 @@ def extract_conditional_statement(usage_field):
         conditional_statement = usage_field[1:].strip()
     else:
         conditional_statement = None
+    # Normalize capitalization inconsistencies (e.g. 'Frame' -> 'frame')
+    if conditional_statement:
+        conditional_statement = re.sub(r"\bFrame\b", 'frame', conditional_statement)
+        conditional_statement = re.sub(r"\bFrames\b", 'frames', conditional_statement)
     return conditional_statement
 
 


### PR DESCRIPTION
This PR fixes the failing update-standard github Actions workflow so the dicom-standard browser can continue to be updated with the latest dicom standard.

See workflow on my personal branch at https://github.com/StijnvWijn/dicom-standard/actions/runs/24082745895/job/70247352257

Related to at least the following issues:
https://github.com/innolitics/dicom-standard/issues/126
https://github.com/innolitics/dicom-standard/issues/125
https://github.com/innolitics/dicom-standard/issues/116
